### PR TITLE
prevent sequence breaking

### DIFF
--- a/script/mp6212.scp
+++ b/script/mp6212.scp
@@ -15,39 +15,44 @@
 //                                                                            //
 //----------------------------------------------------------------------------//
 ///////////////////////////////////////////////////////////////////////////////
-// ‰Šú‰»ƒXƒNƒŠƒvƒg
+// åˆæœŸåŒ–ã‚¹ã‚¯ãƒªãƒ—ãƒˆ
 ///////////////////////////////////////////////////////////////////////////////
 //-------------------------------------------
 
 function "init"
 {
 	CallFunc("rng:expMult")
-	// ƒCƒxƒ“ƒgƒGƒŠƒAÝ’è§Œä
-	EventAreaEnable( "ST_6212_to6201" , 0 )	//yƒXƒgƒbƒp[F6212‚©‚ç6201‚Ös‚¯‚È‚¢z
+	// ã‚¤ãƒ™ãƒ³ãƒˆã‚¨ãƒªã‚¢è¨­å®šåˆ¶å¾¡
+	EventAreaEnable( "ST_6212_to6201" , 0 )	//ã€ã‚¹ãƒˆãƒƒãƒ‘ãƒ¼ï¼š6212ã‹ã‚‰6201ã¸è¡Œã‘ãªã„ã€‘
 
 	if( FLAG[SF_EVENT_ON] ){
-		// ƒGƒ“ƒgƒŠ[§Œä
-		if( FLAG[GF_TBOX_DUMMY087] && !FLAG[GF_06MP4109_CLEAR_MIST]){			// –¶‚Ì•Y‚¤ŽR–å‚É“ü‚é
-			EntryOn( 03 , 1)	//mp6409v1 ”Z–¶”Å‘åŽ÷ƒ}ƒbƒvON
-			EntryOn( 00 , 0)	//mp4105 ’Êíƒ}ƒbƒvOFF
+		// ã‚¨ãƒ³ãƒˆãƒªãƒ¼åˆ¶å¾¡
+		if( FLAG[GF_TBOX_DUMMY087] && !FLAG[GF_06MP4109_CLEAR_MIST]){			// éœ§ã®æ¼‚ã†å±±é–€ã«å…¥ã‚‹
+			EntryOn( 03 , 1)	//mp6409v1 æ¿ƒéœ§ç‰ˆå¤§æ¨¹ãƒžãƒƒãƒ—ON
+			EntryOn( 00 , 0)	//mp4105 é€šå¸¸ãƒžãƒƒãƒ—OFF
+		}
+
+		//disable lower door if the bridge isnt there
+		if( !FLAG[GF_04MP6201_DIS_OBSTACLE]){
+			EntryOn( 02 , 0)
 		}
 	
-		// ‚k‚o§Œä
-		if( FLAG[GF_05MP1201_IN_MEETING] )	//ƒhƒM‚½‚¿‚É–k•”‚Ìó‹µ‚ð“`‚¦‚é
+		// ï¼¬ï¼°åˆ¶å¾¡
+		if( FLAG[GF_05MP1201_IN_MEETING] )	//ãƒ‰ã‚®ãŸã¡ã«åŒ—éƒ¨ã®çŠ¶æ³ã‚’ä¼ãˆã‚‹
 		{
-			SetChrPos("LP_6212_Altar", -100000.00f, 00.00f, 00.00f)	// y‚k‚oF6212’†‰›‚ÌÕ’dz
+			SetChrPos("LP_6212_Altar", -100000.00f, 00.00f, 00.00f)	// ã€ï¼¬ï¼°ï¼š6212ä¸­å¤®ã®ç¥­å£‡ã€‘
 		}
 
-		// ƒXƒgƒbƒp[§Œä
-		if( FLAG[GF_TBOX_DUMMY087] &&		//’²¸‚Ì‚½‚ßƒWƒƒƒ“ƒ_ƒ‹ƒ€‚ÖŒü‚©‚¤
-			!FLAG[GF_06MP4105B_START_ROOP] )	//–¶‚Ì’†‚ÅˆÙŒ`‚ÌŒÃ‘ãŽí‚Æí‚¤‚P
+		// ã‚¹ãƒˆãƒƒãƒ‘ãƒ¼åˆ¶å¾¡
+		if( FLAG[GF_TBOX_DUMMY087] &&		//èª¿æŸ»ã®ãŸã‚ã‚¸ãƒ£ãƒ³ãƒ€ãƒ«ãƒ ã¸å‘ã‹ã†
+			!FLAG[GF_06MP4105B_START_ROOP] )	//éœ§ã®ä¸­ã§ç•°å½¢ã®å¤ä»£ç¨®ã¨æˆ¦ã†ï¼‘
 		{
-			EventAreaEnable( "ST_6212_to6201" , 1 )	//yƒXƒgƒbƒp[F6212‚©‚ç6201‚Ös‚¯‚È‚¢z
+			EventAreaEnable( "ST_6212_to6201" , 1 )	//ã€ã‚¹ãƒˆãƒƒãƒ‘ãƒ¼ï¼š6212ã‹ã‚‰6201ã¸è¡Œã‘ãªã„ã€‘
 		}
 
-		// ƒAƒNƒeƒBƒuƒ{ƒCƒX
+		// ã‚¢ã‚¯ãƒ†ã‚£ãƒ–ãƒœã‚¤ã‚¹
 		if(!FLAG[GF_AVOICE_0415] && FLAG[GF_04MP6201_DIS_OBSTACLE] && !FLAG[GF_04MP6409_IN_TEM]){
-			//ActiveVoiceStart(EACT_EVID_0415, 1, 0)	//ŽR–å“à‚É“ü‚é‚Æ
+			//ActiveVoiceStart(EACT_EVID_0415, 1, 0)	//å±±é–€å†…ã«å…¥ã‚‹ã¨
 			SetEventDriven(EED_TYPE_TIMER,60,"mp6212:act_0415")
 		}
 	}
@@ -56,30 +61,30 @@ function "init"
 function "act_0415"
 {
 	ActiveVoiceStop(ACTIVEVOICESTOP_WINDOWOFF)
-	ActiveVoiceStart(EACT_EVID_0415, 1, 0)	//ŽR–å“à‚É“ü‚é‚Æ
+	ActiveVoiceStart(EACT_EVID_0415, 1, 0)	//å±±é–€å†…ã«å…¥ã‚‹ã¨
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
-//¡ƒƒCƒ“ƒCƒxƒ“ƒgƒZƒNƒVƒ‡ƒ“
+//â– ãƒ¡ã‚¤ãƒ³ã‚¤ãƒ™ãƒ³ãƒˆã‚»ã‚¯ã‚·ãƒ§ãƒ³
 
 ////////////////////////////////////////////////////////////////////////////////
 
 ////////////////////////////////////////////////////////////////////////////////
 
-//¡ƒXƒgƒbƒp[E‚k‚oƒZƒNƒVƒ‡ƒ“
+//â– ã‚¹ãƒˆãƒƒãƒ‘ãƒ¼ãƒ»ï¼¬ï¼°ã‚»ã‚¯ã‚·ãƒ§ãƒ³
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //	================================================
-//	y‚k‚oF6212’†‰›‚ÌÕ’dz
+//	ã€ï¼¬ï¼°ï¼š6212ä¸­å¤®ã®ç¥­å£‡ã€‘
 //	================================================
 function "LP_6212_Altar"
 {
-	//¥`IGF_05MP1201_IN_MEETING,			//ƒhƒM‚½‚¿‚É–k•”‚Ìó‹µ‚ð“`‚¦‚é
-	//@@-316.04f	691.74f	51.36f	-25.29f•t‹ß‚ÌÕ’d‚É‚k‚o‚ð‚µ‚©‚¯‚é
+	//â–¼ï½žï¼GF_05MP1201_IN_MEETING,			//ãƒ‰ã‚®ãŸã¡ã«åŒ—éƒ¨ã®çŠ¶æ³ã‚’ä¼ãˆã‚‹
+	//ã€€ã€€-316.04f	691.74f	51.36f	-25.29fä»˜è¿‘ã®ç¥­å£‡ã«ï¼¬ï¼°ã‚’ã—ã‹ã‘ã‚‹
 
-//ŠJŽnˆ—‚±‚±‚©‚ç----------------------------------------------------
+//é–‹å§‹å‡¦ç†ã“ã“ã‹ã‚‰----------------------------------------------------
 	SetStopFlag(STOPFLAG_SIMPLEEVENT2)
 	ResetStopFlag(STOPFLAG_NOCHARACLIP)
 	SaveCamera()
@@ -88,29 +93,29 @@ function "LP_6212_Altar"
 	StopEffect(-1,PARTYALL,1)
 	StopEmotion( "PARTYALL" )
 	ResetMoveVec("PARTYALL")
-//ŠJŽnˆ—‚±‚±‚Ü‚Å-----------------------------------------------
+//é–‹å§‹å‡¦ç†ã“ã“ã¾ã§-----------------------------------------------
 
 	TurnToChr( LEADER , this , 7.5f )
 	Wait(10)
 
-	//	ƒeƒLƒXƒg
+	//	ãƒ†ã‚­ã‚¹ãƒˆ
 	TalkPopup(UNDEF,0,3,SYSTEM_PPOSX,SYSTEM_PPOSY,0)
 	{
-		"#7C‰½‚©‚ÌÕ’d‚Ì‚æ‚¤‚¾‚ªcc"
+		"#7Cä½•ã‹ã®ç¥­å£‡ã®ã‚ˆã†ã ãŒâ€¦â€¦"
 	}
 	WaitPrompt()
 	WaitCloseWindow()
 
-//I—¹ˆ—‚±‚±‚©‚ç----------------------------------------------------
+//çµ‚äº†å‡¦ç†ã“ã“ã‹ã‚‰----------------------------------------------------
 	CrossFade(FADE_CROSS)
 	SetStopFlag(STOPFLAG_NOCHARACLIP)
 
-	//ƒCƒxƒ“ƒgŒã‚ÌÄ”z’u
+	//ã‚¤ãƒ™ãƒ³ãƒˆå¾Œã®å†é…ç½®
 //	SetChrPos("LEADER",0.00f,0.00f,0.00f)
 //	Turn("LEADER",0.00f,360.0f)
 	ResetPartyPos()
 	ResetFollowPoint()
-	//Wait(1) //ˆ—‘Ò‚¿—p
+	//Wait(1) //å‡¦ç†å¾…ã¡ç”¨
 
 	RestoreCamera(0,0)
 	ResetCameraObserver(0)
@@ -118,21 +123,21 @@ function "LP_6212_Altar"
 	Wait(FADE_CROSS)
 
 	ResetStopFlag(STOPFLAG_SIMPLEEVENT2)
-//I—¹ˆ—‚±‚±‚Ü‚Å----------------------------------------------------
+//çµ‚äº†å‡¦ç†ã“ã“ã¾ã§----------------------------------------------------
 }
 
 //	================================================
-//	yƒXƒgƒbƒp[F6212‚©‚ç6201‚Ös‚¯‚È‚¢z
+//	ã€ã‚¹ãƒˆãƒƒãƒ‘ãƒ¼ï¼š6212ã‹ã‚‰6201ã¸è¡Œã‘ãªã„ã€‘
 //	================================================
 function "ST_6212_to6201"
 {
-	//¥GF_TBOX_DUMMY087,				//’²¸‚Ì‚½‚ßƒWƒƒƒ“ƒ_ƒ‹ƒ€‚ÖŒü‚©‚¤
-	//	`IGF_06MP4105B_START_ROOP,		//–¶‚Ì’†‚ÅˆÙŒ`‚ÌŒÃ‘ãŽí‚Æí‚¤‚P
-	//	//0519’Ç‰Á
+	//â–¼GF_TBOX_DUMMY087,				//èª¿æŸ»ã®ãŸã‚ã‚¸ãƒ£ãƒ³ãƒ€ãƒ«ãƒ ã¸å‘ã‹ã†
+	//	ï½žï¼GF_06MP4105B_START_ROOP,		//éœ§ã®ä¸­ã§ç•°å½¢ã®å¤ä»£ç¨®ã¨æˆ¦ã†ï¼‘
+	//	//0519è¿½åŠ 
 
-//ŠJŽnˆ—‚±‚±‚©‚ç----------------------------------------------------
-	// PLAYER2‚ÆPLAYER3‚Ì‚Ç‚¿‚ç‚©‚ªPLAYER1‚©‚çˆê’è‹——£—£‚ê‚Ä‚¢‚½‚ç
-	// PLAYER1‚Ì‚»‚Î‚Éƒ[ƒv‚·‚é
+//é–‹å§‹å‡¦ç†ã“ã“ã‹ã‚‰----------------------------------------------------
+	// PLAYER2ã¨PLAYER3ã®ã©ã¡ã‚‰ã‹ãŒPLAYER1ã‹ã‚‰ä¸€å®šè·é›¢é›¢ã‚Œã¦ã„ãŸã‚‰
+	// PLAYER1ã®ãã°ã«ãƒ¯ãƒ¼ãƒ—ã™ã‚‹
 	SetFlag( TF_CHECK_DISTANCE, 1 )
 	SetFlag( TF_CHECK_DISTANCE2, 1 )
 	if( WORK[WK_ISEXIST_PLAYER2] )
@@ -169,24 +174,24 @@ function "ST_6212_to6201"
 	}
 	WaitThread(1)
 	WaitThread(2)
-//ŠJŽnˆ—‚±‚±‚Ü‚Å-----------------------------------------------
+//é–‹å§‹å‡¦ç†ã“ã“ã¾ã§-----------------------------------------------
 
 	TalkPopup("DANA",0,3,STOPPER_PPOSX,STOPPER_PPOSY,0)
 	{
-		"#000e#000m‘åŽ÷‚ÌŽ›‰@‚Í"
-		"‚±‚±‚ð“ì‚É”²‚¯‚½Š‚¾‚ËB\p"
-		"ƒAƒhƒ‹‚³‚ñA‹}‚¢‚ÅŒü‚©‚¨‚¤I"
+		"#000e#000må¤§æ¨¹ã®å¯ºé™¢ã¯"
+		"ã“ã“ã‚’å—ã«æŠœã‘ãŸæ‰€ã ã­ã€‚\p"
+		"ã‚¢ãƒ‰ãƒ«ã•ã‚“ã€æ€¥ã„ã§å‘ã‹ãŠã†ï¼"
 	}
 	WaitPrompt()
 	WaitCloseWindow()
 
-//I—¹ˆ—‚±‚±‚©‚ç----------------------------------------------------
+//çµ‚äº†å‡¦ç†ã“ã“ã‹ã‚‰----------------------------------------------------
 	CrossFade(FADE_CROSS)
 	SetChrPos("PLAYER1",-329.34f,724.53f,42.90f)
 	Turn("PLAYER1",-22.58f,360.0f)
 	ResetPartyPos()
 	ResetFollowPoint()
-	//Wait(1) //ˆ—‘Ò‚¿—p
+	//Wait(1) //å‡¦ç†å¾…ã¡ç”¨
 
 	RestoreCamera(0,0)
 	ResetCameraObserver(0)
@@ -194,5 +199,5 @@ function "ST_6212_to6201"
 	Wait(FADE_CROSS)
 
 	ResetStopFlag(STOPFLAG_SIMPLEEVENT2)
-//I—¹ˆ—‚±‚±‚Ü‚Å----------------------------------------------------
+//çµ‚äº†å‡¦ç†ã“ã“ã¾ã§----------------------------------------------------
 }


### PR DESCRIPTION
disables the loading zone between the staircase to the temple of the great tree. when this loading zone is active leaving through it while the tree bridge is not active causes the player to instantly void and respawn on the other side of the chasam, allowing progress to the eternian ruins without need for the bridge to be there