### PR TITLE
Cleaning some map markers, a dialogue, and fixing kong fight when licht is there

### DIFF
--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -198,15 +198,15 @@ def canAccess(inventory,location,parameters):
         if location.locName == 'Mishy Rewards' and access.canDefeat('Avalodragil 2'):
             if location.mapCheckID == 'Food 2' and access.canCook(1): return True
             elif location.mapCheckID == 'Food 4' and access.canCook(2): return True
-            elif location.mapCheckID == 'Food 4' and access.canCook(3): return True
-            elif location.mapCheckID == 'Food 4' and access.canCook(4): return True
-            elif location.mapCheckID == 'Food 4' and access.canCook(5): return True
-            elif location.mapCheckID == 'Food 4' and access.canCook(6): return True
+            elif location.mapCheckID == 'Food 6' and access.canCook(3): return True
+            elif location.mapCheckID == 'Food 8' and access.canCook(4): return True
+            elif location.mapCheckID == 'Food 10' and access.canCook(5): return True
+            elif location.mapCheckID == 'Food 12' and access.canCook(6): return True
             else: return False
         elif location.locName == 'Mid-Boss Arena' and battleLogic(140,access,parameters): return True
         elif location.locName in ['Upper Cliffs 1','Upper Cliffs 2'] and access.canDefeat('Avalodragil 2'): return True
         elif location.locName == 'Boss Arena': 
-            if location.mapCheckID in ['Giasburn Skill 1','Giasburn Skill 2','Giasburn'] and battleLogic(230,access,parameters): return True
+            if location.mapCheckID in ['Giasburn Skill 1','Giasburn Skill 2','Giasburn'] and battleLogic(230,access,parameters) and access.hasFlameStones(3): return True
             elif location.mapCheckID in ['Master Kong Skill Laxia','Master Kong Laxia'] and battleLogic(220,access,parameters) and access.hasLaxia() and access.canDefeat('Master Kong Dana'): return True
             elif location.mapCheckID == 'Psyches' and parameters.goal == 'Release the Psyches' and battleLogic(340,access,parameters) and access.canDefeat('Giasburn'): return True
             else: return False

--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -351,7 +351,7 @@ def canAccess(inventory,location,parameters):
             elif location.mapCheckID == 'TBOX02' and (access.canSwampWalk() or access.canUnderwater()): return True
             else: return False
         elif location.locName == 'Muddy Lake' and access.canSwampWalk(): return True
-        elif location.locName == 'Exit to Valley of Kings'  and (access.canSwampWalk() or (access.canDoubleJump() and access.canUnderwater())): 
+        elif location.locName == 'Exit to Valley of Kings' and access.past6() and (access.canSwampWalk() or (access.canDoubleJump() and access.canUnderwater())): 
             if location.mapCheckID == 'Fermented Sap' and access.canSwampWalk() and access.canDoubleJump(): return True
             elif location.mapCheckID != 'Fermented Sap': return True
             else: return False

--- a/randomizer/crew.py
+++ b/randomizer/crew.py
@@ -11,16 +11,16 @@ def getCrewFlags(name):
     GetItem(ICON3D_WP_ADOL_000,1)
     EquipWeapon(ADOL,ICON3D_WP_ADOL_000)
     
-    if( FLAG[GF_03MP1201_ALARM_INTERCEPT] && !FLAG[GF_TBOX_DUMMY071])
-    {
-        GetItem(ICON3D_WP_ADOL_003, 1)		
-	    EquipWeapon(ADOL, ICON3D_WP_ADOL_003)
-    }
-    if( FLAG[GF_TBOX_DUMMY071] && !FLAG[GF_TBOX_DUMMY109])
+    if( ITEMWORK[ICON3D_WP_ADOL_008] )
     {
         SetFlag(GF_ADOLWEAPON_BACKUP,(ADOL.CHRWORK[CWK_WEAPON]))
         GetItem(ICON3D_WP_ADOL_008, 1)		
 	    EquipWeapon(ADOL, ICON3D_WP_ADOL_008)
+    }
+    else if( FLAG[GF_03MP1201_ALARM_INTERCEPT] )
+    {
+        GetItem(ICON3D_WP_ADOL_003, 1)		
+	    EquipWeapon(ADOL, ICON3D_WP_ADOL_003)
     }
     
     JoinParty(PARTY_ADOL)

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -26,6 +26,7 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
     spoilerLog.write("Fish Trades: " + str(parameters.fishTrades) + "\n")
     spoilerLog.write("Doggi Intercept Rewards: " + str(parameters.dogiRewards) + "\n")
     spoilerLog.write("Master Kong: " + str(parameters.mkRewards) + "\n")
+    spoilerLog.write("Silvia: " + str(parameters.silvia) + "\n")
     spoilerLog.write("Maphorash: " + str(parameters.maphorash) + "\n")
     spoilerLog.write("Additional Intercept Rewards: " + str(parameters.intRewards) + "\n")
     spoilerLog.write("Skills w/ Boss Bonuses: " + str(parameters.shuffleSkills) + "\n")

--- a/script/mp1101.scp
+++ b/script/mp1101.scp
@@ -3033,7 +3033,8 @@ function "EV_M01S170_ED"
 	SetFlag( GF_HELP_A14, 1 )	// チュートリアル：地図を使った移動
 	SetFlag( GF_HELP_A46, 1 )	// チュートリアル：地図アイコン一覧		// 0512追加
 
-	SetMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S180, 54.36f, -1220.11f, 8.06f, 54.36f, -1220.11f, MARKER_EV_M01S180, MN_F_SOUTHWEST_PLANE_MP1103,0)	// 地図作りを開始した			mp1103:サハド合流
+	// removing a main event marker on avalodragil 1
+	// SetMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S180, 54.36f, -1220.11f, 8.06f, 54.36f, -1220.11f, MARKER_EV_M01S180, MN_F_SOUTHWEST_PLANE_MP1103,0)	// 地図作りを開始した			mp1103:サハド合流
 
 	SetFlag( GF_MPxxxx_MAP_NAME_NO_DRAW, 0)		// 地名表示制御
 	CallFunc( "mp1101:init" )

--- a/script/mp1101.scp
+++ b/script/mp1101.scp
@@ -3949,7 +3949,8 @@ function "EV_M02S540_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 	SetFlag( SF_WARP_DISABLED, 0 )		//ƒ[ƒvg—p‰Â”\
 
 	//ƒ}ƒbƒvƒ}[ƒJ[
-	SetMapMarker(SMI_SYMBOL,PAGE_F005,MARKER_EV_M02S550,665.18f,-1616.51f,1.63f,665.18f,-1616.51f,MARKER_EV_M02S550, MN_F_MP1134,0)	//ƒJ[ƒ‰ƒ“‹¨‚Ì‹~o‚ÉŒü‚©‚¤
+	// commeting this out to remove main event marker in white sand cape
+	// SetMapMarker(SMI_SYMBOL,PAGE_F005,MARKER_EV_M02S550,665.18f,-1616.51f,1.63f,665.18f,-1616.51f,MARKER_EV_M02S550, MN_F_MP1134,0)	//ƒJ[ƒ‰ƒ“‹¨‚Ì‹~o‚ÉŒü‚©‚¤
 
 	CallFunc("mp1101:init" )
 
@@ -3973,7 +3974,8 @@ function "EV_M02S540_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 
 	ResetStopFlag(STOPFLAG_EVENT)
 
-	FadeIn(FADE_BLACK,FADE_FAST)
+	// removing an extra fade when leaving village during kieergard chase
+	//FadeIn(FADE_BLACK,FADE_FAST)
 	//WaitFade()
 	//I—¹ˆ—‚±‚±‚Ü‚Å----------------------------------------------------
 }
@@ -4669,7 +4671,8 @@ function "EV_M02S600_ED"
 	//SetFlag( SF_WARP_DISABLED, 1 )		//ƒ[ƒvg—p‹Ö~
 
 	//ƒ}ƒbƒvƒ}[ƒJ[
-	SetMapMarker(SMI_EVENTPT_MAIN, PAGE_F001, MARKER_EV_M02S610, 76.56f, -1402.34f, 12.83f, 76.56f, -1402.34f, 0, MN_F_SOUTHWEST_PLANE_MP1101,0)	//|ü	ƒ~ƒjƒ}ƒbƒv‚Ì‚İ
+	// removing that wire marker outside village
+	// SetMapMarker(SMI_EVENTPT_MAIN, PAGE_F001, MARKER_EV_M02S610, 76.56f, -1402.34f, 12.83f, 76.56f, -1402.34f, 0, MN_F_SOUTHWEST_PLANE_MP1101,0)	//|ü	ƒ~ƒjƒ}ƒbƒv‚Ì‚İ
 
 	CallFunc( "mp1101:init" )
 
@@ -4693,7 +4696,8 @@ function "EV_M02S600_ED"
 
 	ResetStopFlag(STOPFLAG_EVENT)
 
-	FadeIn(FADE_BLACK,FADE_FAST)
+	// removing extra fade when leaving village during kiergaard chase
+	//FadeIn(FADE_BLACK,FADE_FAST)
 	//WaitFade()
 
 //I—¹ˆ—‚±‚±‚Ü‚Å----------------------------------------------------
@@ -5764,7 +5768,8 @@ function "EV_M02S640_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 	//SetFlag( SF_WARP_DISABLED, 1 )		//ƒ[ƒvg—p‹Ö~
 
 	//ƒ}ƒbƒvƒ}[ƒJ[
-	SetMapMarker( SMI_SYMBOL,PAGE_F001,MARKER_EV_M02S650,132.39f, -1277.01f, 3.53f,132.39f, -1277.01f,MARKER_EV_M02S650, MN_F_SOUTHWEST_PLANE_MP1111,0)	//ƒoƒ‹ƒoƒƒX•‰
+	// removing marker on barbaros and quina during kiergaard chase
+	// SetMapMarker( SMI_SYMBOL,PAGE_F001,MARKER_EV_M02S650,132.39f, -1277.01f, 3.53f,132.39f, -1277.01f,MARKER_EV_M02S650, MN_F_SOUTHWEST_PLANE_MP1111,0)	//ƒoƒ‹ƒoƒƒX•‰
 
 	CallFunc("mp1101:init" )
 
@@ -5783,7 +5788,8 @@ function "EV_M02S640_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 	SetFlag( SF_NOUSE_MTDSE, 0 )
 	FadeBGM(100,30)
 
-	FadeIn(FADE_BLACK,FADE_FAST)
+	// removing extra fade
+	//FadeIn(FADE_BLACK,FADE_FAST)
 	//WaitFade()
 
 //I—¹ˆ—‚±‚±‚Ü‚Å----------------------------------------------------

--- a/script/mp1101.scp
+++ b/script/mp1101.scp
@@ -3291,7 +3291,9 @@ function "EV_M02S060_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 
 	//ƒ}[ƒJ[ƒZƒbƒg
 //	SetMapMarker(SMI_EVENTPT_MAIN,PAGE_F001,REMOVE_OBJ_1110,251.44f,-1508.45f,6.94f,251.44f,-1508.45f,0, MN_F_SOUTHWEST_PLANE_MP1110,0)	//“|–Ø		‘¶İ‚ğ’m‚ç‚È‚¢‚Ì‚ÅƒZƒbƒg‚µ‚È‚¢
-	SetMapMarker(SMI_SYMBOL ,PAGE_F005, MARKER_EV_M02S080, 515.95f, -1607.85f, 0.13f, 515.95f, -1607.85f,MARKER_EV_M02S080,MN_F_MP1133,0)	//•Y—¬ÒFƒAƒŠƒXƒ“
+
+	// commenting this out to remove main event marker on alison
+	// SetMapMarker(SMI_SYMBOL ,PAGE_F005, MARKER_EV_M02S080, 515.95f, -1607.85f, 0.13f, 515.95f, -1607.85f,MARKER_EV_M02S080,MN_F_MP1133,0)	//•Y—¬ÒFƒAƒŠƒXƒ“
 
 	SetChrPos("LEADER", 51.90f, -1406.36f, 10.70f)
 	Turn("LEADER",-130.57f,360.0f)

--- a/script/mp1103.scp
+++ b/script/mp1103.scp
@@ -3862,7 +3862,8 @@ function "EV_M01S182_ED"
 		SetFlag(GF_GALL_EV_01_04,1)			// M01S181:サハド抱きつく
 
 		//マーカー
-		DelMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S180, 0, 0)	// 地図作りを開始した			mp1103:サハド合流
+		// This main event marker was commented out in mp1101
+		// DelMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S180, 0, 0)	// 地図作りを開始した			mp1103:サハド合流
 
 		// commenting this out to remove main event marker in castaway
 		// SetMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S190, 39.73f, -1414.10f, 10.81f, 39.73f, -1414.10f, MARKER_EV_M01S190, MN_T_VILLAGE_MP1201,0)	// //拠点に戻ってドギと再会

--- a/script/mp1103.scp
+++ b/script/mp1103.scp
@@ -3864,7 +3864,8 @@ function "EV_M01S182_ED"
 		//マーカー
 		DelMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S180, 0, 0)	// 地図作りを開始した			mp1103:サハド合流
 
-		SetMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S190, 39.73f, -1414.10f, 10.81f, 39.73f, -1414.10f, MARKER_EV_M01S190, MN_T_VILLAGE_MP1201,0)	// //拠点に戻ってドギと再会
+		// commenting this out to remove main event marker in castaway
+		// SetMapMarker(SMI_SYMBOL, PAGE_F001, MARKER_EV_M01S190, 39.73f, -1414.10f, 10.81f, 39.73f, -1414.10f, MARKER_EV_M01S190, MN_T_VILLAGE_MP1201,0)	// //拠点に戻ってドギと再会
 
 		CallFunc("mp1103:init" )
 

--- a/script/mp1103.scp
+++ b/script/mp1103.scp
@@ -6163,7 +6163,8 @@ function "EV_M02S670_ED"
 
 		//マップマーカー
 		DelMapMarker( SMI_SYMBOL,PAGE_MP120x,MARKER_EV_M02S660, 0, 0)
-		SetMapMarker(SMI_EVENTPT_MAIN,PAGE_F001,MARKER_EV_M02S680,137.03f,-1279.23f,3.30f,137.03f,-1279.23f,0, MN_F_SOUTHWEST_PLANE_MP1111,0)	//キルゴール
+		// removing a main event marker on barbaros after defeating kiergaard
+		// SetMapMarker(SMI_EVENTPT_MAIN,PAGE_F001,MARKER_EV_M02S680,137.03f,-1279.23f,3.30f,137.03f,-1279.23f,0, MN_F_SOUTHWEST_PLANE_MP1111,0)	//キルゴール
 
 		//ＢＧＭ復帰
 		PlayBGM(BGM_1103, 15)

--- a/script/mp1111.scp
+++ b/script/mp1111.scp
@@ -91,7 +91,8 @@ function "init"
 		if( FLAG[GF_02MP1111_WOUND_BARBAROSS] &&	// バルバロスが致命傷を負う
 			!FLAG[GF_02MP1103_KILL_KIERGAARD] )			//ダーナ編①	植樹祭の説明を受ける
 		{
-			EventAreaEnable( "ST_1111_to1131" , 1 )	// 【ストッパー：1111⇒1131】
+			// disabling this trigger to prevent it when we come from 1131
+			EventAreaEnable( "ST_1111_to1131" , 0 )	// 【ストッパー：1111⇒1131】
 		}
 		
 
@@ -4206,8 +4207,9 @@ function "SubEV_Sien02"
 		
 		SetMapMarker( SMI_SUBEVENT ,PAGE_F001, REMOVE_OBJ_2101, 53.73f, -919.31f, 13.52f, 53.73f, -919.31f,REMOVE_OBJ_2101,MN_F_SOUTHWEST_PLANE_MP2101,0)		//協力　：大河流域へ
 		SetMapMarker( SMI_SUBEVENT ,PAGE_F001, REMOVE_OBJ_1131, -26.99f,-1292.62f,24.43f, -26.99f,-1292.62f,REMOVE_OBJ_1131,MN_F_SOUTHWEST_PLANE_MP1131,0)		//協力　：風見の高原へ
-		
-		SetMapMarker( SMI_SYMBOL ,PAGE_F001, MARKER_EV_M02S100, -201.62f,-881.93f,40.71f, -201.62f,-881.93f ,MARKER_EV_M02S100, MN_F_SOUTHWEST_PLANE_MP1105,0)	//珊瑚野営地
+
+		// commenting this out to remove main event marker on coral camp		
+		// SetMapMarker( SMI_SYMBOL ,PAGE_F001, MARKER_EV_M02S100, -201.62f,-881.93f,40.71f, -201.62f,-881.93f ,MARKER_EV_M02S100, MN_F_SOUTHWEST_PLANE_MP1105,0)	//珊瑚野営地
 		
 		SetFlag( TF_MENU_SELECT, 1 )	//支援イベントとして終了
 

--- a/script/mp1115.scp
+++ b/script/mp1115.scp
@@ -744,6 +744,9 @@ function "Join_Reja2_ED"
 	WaitPrompt()
 	WaitCloseWindow()
 
+	// Remove the pikkard green subevent marker on the map
+	DelMapMarker( SMI_SUBEVENT, PAGE_F012, MARKER_JOIN_REJA, 862.16f, -903.34f, 9.22f, 862.16f, -903.34f, MARKER_JOIN_REJA, MN_F_MP1115, -1)
+
 	//NowLoading 時の Tips 表示をカット
 	SetFlag( TF_LOADING_TIPS_OFF, 1 )
 	ResetStopFlag(STOPFLAG_EVENT)

--- a/script/mp1118.scp
+++ b/script/mp1118.scp
@@ -1675,6 +1675,9 @@ function "Speedrun_Monkey3_Battle"
 
 //開始処理ここから----------------------------------------------------
 
+	// adding this line to disable licth event trigger during kong fight
+	EventAreaEnable( "evc_M02S430" , 0 )
+
 	CallFunc("system:event_begin")
 
 	//イベント開始前情報の保存

--- a/script/mp1201.scp
+++ b/script/mp1201.scp
@@ -37403,7 +37403,8 @@ function "EV_M03S260_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 	//SetFlag( SF_MISSIONNO, MS_03_10 )	//š–`Œ¯ƒƒ‚FƒWƒƒƒ“ƒ_ƒ‹ƒ€‚ğ’Tõ‚µ‚æ‚¤B
 
 	//ƒ}[ƒJ[ƒZƒbƒg
-	SetMapMarker( SMI_SYMBOL, PAGE_MP433x, MARKER_EV_M03S270, 427.57f, -9.42f, 759.63f, 427.57f, -9.42f, MARKER_EV_M03S270, MN_D_MP4341,0)	//—ƒ—³Œ^ŒÃ‘ãí“oê
+	// removing main event marker on giasburn after obtaining orichalcum
+	// SetMapMarker( SMI_SYMBOL, PAGE_MP433x, MARKER_EV_M03S270, 427.57f, -9.42f, 759.63f, 427.57f, -9.42f, MARKER_EV_M03S270, MN_D_MP4341,0)	//—ƒ—³Œ^ŒÃ‘ãí“oê
 	
 	CallFunc( "talk:TalkFlag_Clear" )	// TFƒtƒ‰ƒO‚ğ‘S‚Ä‰Šú‰»‚·‚éi•Y—¬‘º‚Åˆê”Êƒtƒ‰ƒO‚ªXV‚³‚ê‚éêŠ‘S‚Ä‚Ås‚Á‚Ä‚¢‚Ü‚·j
 	CallFunc("mp1201:init")

--- a/script/mp1201.scp
+++ b/script/mp1201.scp
@@ -28574,8 +28574,8 @@ function "EV_M02S620_ED"
 
 	//マップマーカー
 	DelMapMarker( SMI_EVENTPT_MAIN,PAGE_F001,MARKER_EV_M02S610, 0, 0)
-
-	SetMapMarker(SMI_EVENTPT_MAIN,PAGE_MP120x,MARKER_EV_M02S620,-3.66f,-1476.07f,24.58f,-3.66f,-1476.07f,0, MN_T_VILLAGE_MP1201,0)	//キルゴール
+	// removing a main event marker on kieergard
+	// SetMapMarker(SMI_EVENTPT_MAIN,PAGE_MP120x,MARKER_EV_M02S620,-3.66f,-1476.07f,24.58f,-3.66f,-1476.07f,0, MN_T_VILLAGE_MP1201,0)	//キルゴール
 
 	CallFunc( "talk:TalkFlag_Clear" )	// TFフラグを全て初期化する（漂流村で一般フラグが更新される場所全てで行っています）
 	CallFunc("mp1201:init" )

--- a/script/mp1213.scp
+++ b/script/mp1213.scp
@@ -3252,6 +3252,7 @@ function "QS_611_Lose_ED"
 
 function "QS_611_Complete"
 {
+	SetFlag(SF_BOSS_BATTLE, 0)
 	FadeOut(FADE_BLACK,FADE_FAST)
 	WaitFade()
 	CallFunc("mp1213:QS_611_Complete_ED")

--- a/script/mp1303.scp
+++ b/script/mp1303.scp
@@ -578,7 +578,8 @@ function "EV_M02S190_ED"											//ƒCƒxƒ“ƒgƒXƒLƒbƒv—p‚ÉI—¹ˆ—‚ğ•Ê‚Ìfunction‚
 	Portrait_Unload(-1)
 
 	// ¦ƒZ[ƒuƒ[ƒh‚â“¯ƒ}ƒbƒvØ‘Ö‚ğ‚µ‚½ê‡AÄ“xƒRƒ}ƒ“ƒh‚ğŒÄ‚Ño‚·•K—v‚ª‚ ‚è‚Ü‚·B
-	SetEventDriven(EED_TYPE_EQUIPMAGICITEM, ICON3D_CLIMBGLOVE, "mp1303:EV_M02S190_Help")
+	// removing the grip gloves tutorial
+	// SetEventDriven(EED_TYPE_EQUIPMAGICITEM, ICON3D_CLIMBGLOVE, "mp1303:EV_M02S190_Help")
 
 	//ƒtƒ‰ƒOˆ—
 	SetFlag( GF_02MP1306_GET_GROVE , 1 )			// ƒOƒ[ƒu‚ğ“üè‚µ‚½

--- a/script/mp6301.scp
+++ b/script/mp6301.scp
@@ -1854,7 +1854,8 @@ function "EV_M06S204_ED"
 	CallFunc("mp6301:init")
 
 	//マップマーカー
-	SetMapMarker( SMI_SYMBOL ,PAGE_MP634x, MARKER_EV_M06S210, 933.99f, 0.02f, -95.82f, 933.99f, 0.02f,MARKER_EV_M06S210,MN_D_MP6350v1,3)		//メイン：想剣ミストルティンを入手する
+	// removing main event mark in seren after defeating sarai
+	// SetMapMarker( SMI_SYMBOL ,PAGE_MP634x, MARKER_EV_M06S210, 933.99f, 0.02f, -95.82f, 933.99f, 0.02f,MARKER_EV_M06S210,MN_D_MP6350v1,3)		//メイン：想剣ミストルティンを入手する
 
 	//イベント後の再配置
 	SetChrPos("LEADER",53.50f,-185.80f,-12.00f)

--- a/script/talk.scp
+++ b/script/talk.scp
@@ -27209,8 +27209,8 @@ function "Talk_Katrin"
 		else
 		{
 			SetFlag(GF_ADOLWEAPON_BACKUP,(ADOL.CHRWORK[CWK_WEAPON]))
-			GetItem(ICON3D_WP_ADOL_008,1)
 			EquipWeapon(ADOL,ICON3D_WP_ADOL_008)
+			GetItem(ICON3D_WP_ADOL_008,1)
 			DeleteItem(ICON3D_WP_ADOL_009,1)
 			FadeIn(FADE_BLACK,FADE_NORMAL)
 			WaitFade()
@@ -27258,8 +27258,8 @@ function "Talk_Katrin"
 		}
 		else
 		{
-			GetItem(ICON3D_WP_DANA_005,1)
 			EquipWeapon(DANA,ICON3D_WP_DANA_005)
+			GetItem(ICON3D_WP_DANA_005,1)
 			DeleteItem(ICON3D_WP_ADOL_009,1)
 			FadeIn(FADE_BLACK,FADE_NORMAL)
 			WaitFade()

--- a/shared/classr.py
+++ b/shared/classr.py
@@ -97,7 +97,7 @@ class access:
         break
 
     for item in self.inventoryObjects:
-      if item.crew and item.itemName != 'Little Paro' and item.itemId != 778: #I used the curran2 and austen2 NPC allocated space to make kong and shoebill count towards village totals, there wasn't another free one for paro but paro is a small bird anyway so it's logical he doesn't count for moving obstacles
+      if item.crew and item.itemName != 'Little Paro' and item.itemID != 778: #I used the curran2 and austen2 NPC allocated space to make kong and shoebill count towards village totals, there wasn't another free one for paro but paro is a small bird anyway so it's logical he doesn't count for moving obstacles
         count+=1
 
     if count >= requiredCrew:

--- a/shared/classr.py
+++ b/shared/classr.py
@@ -97,7 +97,7 @@ class access:
         break
 
     for item in self.inventoryObjects:
-      if item.crew and item.itemName != 'Little Paro': #I used the curran2 and austen2 NPC allocated space to make kong and shoebill count towards village totals, there wasn't another free one for paro but paro is a small bird anyway so it's logical he doesn't count for moving obstacles
+      if item.crew and item.itemName != 'Little Paro' and item.itemId != 778: #I used the curran2 and austen2 NPC allocated space to make kong and shoebill count towards village totals, there wasn't another free one for paro but paro is a small bird anyway so it's logical he doesn't count for moving obstacles
         count+=1
 
     if count >= requiredCrew:


### PR DESCRIPTION
I made the following changes:
 - if licth event and dana kong are both present, while fighting kong the licth event is disabled
 - after completing reja quest (return his pikkard) the green event marker on the pikkard is removed
 - removed all  main event markers on the map that never got deleted 
 - removed some excessive event fade ins that happen after leaving the village during kiergaard chase
 - now you don't get a message pop up when entering the beach map during kiergaard chase
 - removed a main event marker in avalodragil 1 room after beating waterdrop cave and leaving the village 
 - removed the grip gloves tutorial in coral woods (room after miniboss)

commit 2:
 - I updated the logic so that accessing the area Lodinia Marshland - Exit to Valley of Kings now requires access.past6() ( Tree to progress in lodinia)

commit 3:
 - Extra flame stones were being counted as castaways in shared/classr canMove() function. so I excluded the items with id = 778 (flame stones) from that second loop

commit 4:
 - when equipping a weapon to an unobtained character, the weapon gets deleted so I swapped EquipWeapon, GetItem in talk.scp so when you fix the super weapons, you keep it in your inventory in 1 interaction
 - changed logic in crew.py on how adol equips his weapons when he joins the party. Now I check if the mistilein is in the inventory in order to equip it. and only check for the alarm_intercept to equip the T3 weapon.