### PR TITLE
fix bad event designations for some locations

### DIFF
--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -511,11 +511,11 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0510,mp1115,Longhorn Coast,Eastern Shore,Reja's Pikkard,1,610,Eggplant Seed,1,0,0,0,0,1,--------,0
 0511,mp6204,Ruins of Eternia,Palace Ruins,Ship Blueprints,1,779,Ship Blueprints,1,1,0,0,0,1,--------,0
 0512,mp0405,Pirate Ship Eleftheria,Deck,Seiren Chart,1,795,Seiren Nautical Chart,1,0,0,0,0,1,--------,0
-0513,mp1116,Nostalgia Cape,Nostalgia Cape,Driftage,0,801,Romun Badge,1,0,0,0,0,1,--------,0
-0514,mp1123,Solitude Island,Magna Carpa,Driftage,0,813,Engraved Pen,1,0,0,0,0,1,--------,0
-0515,mp0402,Pirate Ship Eleftheria,Hold,Corpse,0,818,Iron Knuckle,1,0,0,0,0,1,--------,0
-0516,mp6370,Archeozoic Chasm,Boss Arena,Driftage,0,804,Ship Nameplate,1,0,0,0,0,1,--------,0
-0517,mp7461,Underground Water Vein,Submerged Area,Driftage,0,829,Old Stethoscope,1,0,0,0,0,1,--------,0
+0513,mp1116,Nostalgia Cape,Nostalgia Cape,Driftage,1,801,Romun Badge,1,0,0,0,0,1,--------,0
+0514,mp1123,Solitude Island,Magna Carpa,Driftage,1,813,Engraved Pen,1,0,0,0,0,1,--------,0
+0515,mp0402,Pirate Ship Eleftheria,Hold,Corpse,1,818,Iron Knuckle,1,0,0,0,0,1,--------,0
+0516,mp6370,Archeozoic Chasm,Boss Arena,Driftage,1,804,Ship Nameplate,1,0,0,0,0,1,--------,0
+0517,mp7461,Underground Water Vein,Submerged Area,Driftage,1,829,Old Stethoscope,1,0,0,0,0,1,--------,0
 0518,none,none,none,none,0,13,Spirit Ring Celesdia,1,0,1,0,0,1,--------,0
 0519,none,none,none,none,0,720,Battle Armlet,1,0,1,0,0,1,--------,0
 0520,startingSkill,Adol Starting Skill,Skill 1,Sonic Slide,1,-1,SKILL_ADOL_SP_C1,1,0,1,0,0,0,--------,1


### PR DESCRIPTION
some event locations were marked as not events in the database causing them to not give items properly when collected due to the new chest item handling