### PR TITLE
Added former sanctuary crypt, essence key stone sanity, and some other fixes and changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ These are settings that modify how much players may need to do of certain activi
 
 **Maphorash**: Sets whether Maphorash can block progression. Maphorash is the highest level optional fight in the game and the Silent Tower is high requirement location.
 
+**Former Sanctuary Crypt**: Sets whether Former Sanctuary Crypt is added to the item pool. If turned off the dungeon is closed. All essence key stones are placed within the dungeon unless Essence Key Sanity is on.
+
 ### Pacing Modifiers:
 These are settings that help with the pacing of the rando. Like most randos Seiren Shuffle is designed to be complete-able in a single sitting, these settings are meant to help with that. 
 **Experience Multiplier**: Pretty straighforward, classic multiplier to EXP. I generally reccomend higher values here than what you might be used to in other randos. The new version removes the game's EXP scaling based on enemy level to help smooth the curve out and keep the player from "slingshotting" to high levels too quickly. This has the consequence that enemies give half their base EXP(the base exp value for enemies in Ys 8 is based on them being slightly higher level than the player, if they're considered the same level as the player then they drop to almost half EXP and the scaling patch makes the game think the player is always equal level to the enemy).
@@ -75,7 +77,9 @@ These are settings that help with the pacing of the rando. Like most randos Seir
 **Origin Start Phase**: Sets which phase the Origin fight starts in. First is the mobbing phase, second is the main boss.
 
 ### Misc Settings:  
-**Shuffle BGM**: (This setting will modify the file ./text/bgmtbl.tbl so you may want to make a copy of it if you want to keep the original file) Shuffles the background tracks from the "bgm" folder from the game. This setting also allows for audio files that are external to Ys VIII. In order to add new tracks, add .OGG files to the "bgm" folder in the root directory of Ys VIII.    
+**Shuffle BGM**: (This setting will modify the file ./text/bgmtbl.tbl so you may want to make a copy of it if you want to keep the original file) Shuffles the background tracks from the "bgm" folder from the game. This setting also allows for audio files that are external to Ys VIII. In order to add new tracks, add .OGG files to the "bgm" folder in the root directory of Ys VIII.  
+
+**Essence Key Sanity**: If Former Sanctuary Crypt setting is on, the Essence Key Stones can be placed anywhere in the game and not just within the dungeon itself.
 
 ## New Progression Items
 The randomizer features a variety of new progression items that are meant to take story gated events and turn them into item gated events to improve the overall experience of the rando. 

--- a/Seiren Shuffle.pyw
+++ b/Seiren Shuffle.pyw
@@ -29,6 +29,8 @@ def buttons(inpt):
         parameters.getFinalBoss(app.getOptionBox("Final Boss: "),app.getOptionBox("Theos Start Phase: "),app.getOptionBox("Origin Start Phase: "), \
             app.getOptionBox("Origin Care Package: "))
         parameters.getShuffleBgm(app.getCheckBox("shuffleBGM"))
+        parameters.getEssenceKeySanity(app.getCheckBox("essenceKeySanity"))
+        parameters.getFormerSanctuaryCrypt(app.getCheckBox("formerSanctuaryCrypt"))
         rngPatcherMain(parameters) 
         app.okBox("Task Complete", "Seed Generation Complete!")
         
@@ -162,6 +164,8 @@ with gui('Seiren Shuffle (An Ys 8 Rando)', '700x850',font = {'size':12}) as app:
     app.setCheckBox("silvia", ticked=True)
     app.addNamedCheckBox("Maphorash", "maphorash",4,3)
     app.setCheckBox("maphorash", ticked=True)
+    app.addNamedCheckBox("Former Sanctuary Crypt", "formerSanctuaryCrypt",1,4)
+    app.setCheckBox("formerSanctuaryCrypt", ticked=False)
     app.stopFrame()
     app.stopLabelFrame()
     
@@ -225,8 +229,10 @@ with gui('Seiren Shuffle (An Ys 8 Rando)', '700x850',font = {'size':12}) as app:
 
     app.startLabelFrame("Misc Settings", 7, 0)
     app.setSticky("ew")
-    app.addNamedCheckBox("Shuffle BGM", "shuffleBGM")
+    app.addNamedCheckBox("Shuffle BGM", "shuffleBGM", 0, 1)
     app.setCheckBox("shuffleBGM", ticked=False)
+    app.addNamedCheckBox("Essence Key Sanity", "essenceKeySanity", 0, 2)
+    app.setCheckBox("essenceKeySanity", ticked=False)
     app.stopLabelFrame()
 
     app.startFrame("commands",8,0)

--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -402,7 +402,8 @@ def canAccess(inventory,location,parameters):
         else: return False
     
     elif 'Former Sanctuary Crypt' in location.locRegion and access.hasDina() and (access.past2() or (access.past3() and access.hasDana()))and access.canDefeat('Giasburn') and battleLogic(390,access,parameters):
-        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance': return True
+        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in [TBOX01, TBOX03]: return True
+        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in [TBOX02] and access.canDoubleJump(): return True
         if access.hasEssenceKeyStone(1):
             if location.locRegion == 'Former Sanctuary Crypt - B1':
                 if location.locName in ['First Brazier', 'Boss Arena']: return True

--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -400,6 +400,41 @@ def canAccess(inventory,location,parameters):
             elif parameters.goal == 'Release the Psyches' and access.hasPsyches(parameters.numGoal) and access.hasPsyches(parameters.numOctus): return True
             else: return False
         else: return False
+    
+    elif 'Former Sanctuary Crypt' in location.locRegion and access.hasDina() and (access.past2() or (access.past3() and access.hasDana()))and access.canDefeat('Giasburn') and battleLogic(390,access,parameters):
+        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance': return True
+        if access.hasEssenceKeyStone(1):
+            if location.locRegion == 'Former Sanctuary Crypt - B1':
+                if location.locName in ['First Brazier', 'Boss Arena']: return True
+                elif location.locName == 'North Brazier Room' and access.hasEssenceKeyStone(9): return True
+            elif access.canDoubleJump():
+                if location.locRegion == 'Former Sanctuary Crypt - B2' and location.locName == 'Entrance': return True
+                if access.hasEssenceKeyStone(3):
+                    if location.locRegion == 'Former Sanctuary Crypt - B2' and location.locName == 'Stone and Rock Block Puzzle': return True
+                    if access.canUndead():
+                        if location.locRegion == 'Former Sanctuary Crypt - B2' and location.locName == 'Boss Arena': return True
+                        if access.canSwampWalk():
+                            if location.locRegion == 'Former Sanctuary Crypt - B3':
+                                if location.mapCheckID not in ['TBOX05', 'TBOX06']: return True
+                                if location.mapCheckID in ['TBOX05', 'TBOX06'] and access.hasEssenceKeyStone(9): return True
+                            if location.locRegion == 'Former Sanctuary Crypt - B4':
+                                if location.locName == 'Entrance':
+                                    if location.mapCheckID != 'TBOX02': return True
+                                    if location.mapCheckID == 'TBOX02' and access.canUnderwater(): return True
+                            if access.hasEssenceKeyStone(6):
+                                if location.locRegion == 'Former Sanctuary Crypt - B4':
+                                    if location.locName == 'Frozen Statue Room':
+                                        if location.mapCheckID not in ['TBOX01', 'TBOX04']: return True
+                                        if location.mapCheckID in ['TBOX01', 'TBOX04'] and access.canUnderwater(): return True
+                                    elif location.locName == 'Boss Arena': return True
+                                elif location.locRegion == 'Former Sanctuary Crypt - B5':
+                                    if (location.locName == 'Entrance' and location.mapCheckID in ['TBOX01', 'TBOX02']) or (location.locName == 'Western Hall' and location.mapCheckID == 'TBOX02'):
+                                        if access.hasEssenceKeyStone(9): return True
+                                    else:
+                                        return True
+                                elif location.locRegion == 'Former Sanctuary Crypt - B6': return True
+        return False
+
     else: return False
 
 def canDiscover(access,requiredDiscoveries):

--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -402,8 +402,8 @@ def canAccess(inventory,location,parameters):
         else: return False
     
     elif 'Former Sanctuary Crypt' in location.locRegion and access.hasDina() and (access.past2() or (access.past3() and access.hasDana()))and access.canDefeat('Giasburn') and battleLogic(390,access,parameters):
-        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in [TBOX01, TBOX03]: return True
-        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in [TBOX02] and access.canDoubleJump(): return True
+        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in ['TBOX01', 'TBOX03']: return True
+        if location.locRegion == 'Former Sanctuary Crypt - B1' and location.locName == 'Entrance' and location.mapCheckID in ['TBOX02'] and access.canDoubleJump(): return True
         if access.hasEssenceKeyStone(1):
             if location.locRegion == 'Former Sanctuary Crypt - B1':
                 if location.locName in ['First Brazier', 'Boss Arena']: return True

--- a/randomizer/audioShuffleExtraFiles.py
+++ b/randomizer/audioShuffleExtraFiles.py
@@ -50,8 +50,8 @@ def generate_audio_info():
           #track_length_in_seconds = audio.duration_seconds
 
           # Calculate LoopEnd
-          #loop_end = int(track_length_in_seconds * 48000) - 24000
-          loop_end = len(sf.SoundFile(audio_path)) - 24000
+          #loop_end = int(track_length_in_seconds * 48000)
+          loop_end = len(sf.SoundFile(audio_path))
 
           # Create tuple with filename, LoopFlag, LoopStart, and LoopEnd
           extra_audio_info = (file_base_name, loop_flag, '00000000', f"{loop_end:08d}")

--- a/randomizer/gameStartFunctions.py
+++ b/randomizer/gameStartFunctions.py
@@ -30,6 +30,11 @@ def buildStartParameters(location,parameters):
     GetItem(ICON3D_FD_SEA_SALT,3)
     GetItem(ICON3D_FD_MEAT_02,3)
     """
+    if parameters.formerSanctuaryCrypt:
+        gameSettingFlags = gameSettingFlags + """
+    SetFlag(SF_SYS_CLEARED, 1)
+	SetFlag(GF_SUBEV_PAST_07_CLEAR, 1)
+    """
         
     startParams = """
 function "startParameters"

--- a/randomizer/rngPatcher.py
+++ b/randomizer/rngPatcher.py
@@ -642,10 +642,10 @@ def shopUpgrades(location):
             SetChrWork(DANA,CWK_SUP_STR,(DANA.CHRWORK[CWK_SUP_STR] - 130))
             GetItem(ICON3D_AM_023, 1)
             if( !(FLAG[GF_TBOX_DUMMY108] && !FLAG[GF_TBOX_DUMMY109]) )
-            {
+            {{
                 EquipWeapon(DANA,ICON3D_WP_DANA_000)
                 GetItem(ICON3D_WP_DANA_000,1)
-            }
+            }}
         }}
         else if (!FLAG[GF_TBOX_DUMMY084])
         {{

--- a/randomizer/rngPatcher.py
+++ b/randomizer/rngPatcher.py
@@ -641,8 +641,11 @@ def shopUpgrades(location):
 
             SetChrWork(DANA,CWK_SUP_STR,(DANA.CHRWORK[CWK_SUP_STR] - 130))
             GetItem(ICON3D_AM_023, 1)
-            GetItem(ICON3D_WP_DANA_000, 1)
-            EquipWeapon(DANA,ICON3D_WP_DANA_000)
+            if( !(FLAG[GF_TBOX_DUMMY108] && !FLAG[GF_TBOX_DUMMY109]) )
+            {
+                EquipWeapon(DANA,ICON3D_WP_DANA_000)
+                GetItem(ICON3D_WP_DANA_000,1)
+            }
         }}
         else if (!FLAG[GF_TBOX_DUMMY084])
         {{

--- a/randomizer/rngPatcher.py
+++ b/randomizer/rngPatcher.py
@@ -197,6 +197,20 @@ function "{0}"
    ResetStopFlag(STOPFLAG_TALK)
 }}
 """          
+    if location.itemID == 218: #3 Combat Medals from meladuma check
+        getItemFunction =  """
+function "{0}"
+{{
+    GetItem(ICON3D_AC_067,1)
+	GetItem(ICON3D_AC_068,1)
+	GetItem(ICON3D_AC_069,1)
+    Message("#0CObtained #2C#372ISlash Medal, #2C#373IPierce Medal, \nand#2C#374IStrike Medal.")
+    WaitPrompt()
+    WaitCloseWindow()
+}}
+"""  
+        return getItemFunction.format(scriptName)
+
     return getItemFunction.format(scriptName,itemIcon,itemQuantity,itemSE,message,script)
 
 #function used for all people function generations

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -61,7 +61,7 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
         while True:
             itemFound = 0
             for index,location in enumerate(accessibleLocation):
-                if canAccess(progressionInventory,location,parameters) or location.locRegion.find(blacklistRegion) >= 0:
+                if canAccess(progressionInventory,location,parameters) or any(location.locRegion.find(region) >= 0 for region in blacklistRegion):
                     newLocation = accessibleLocation.pop(index)
                     accessibleItem = classr.inventory(newLocation)
                     if accessibleItem.progression and newLocation.locID not in duplicateChests:

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -24,10 +24,11 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
     spoilerLog.write("Map Completion: " + str(parameters.mapCompletion) + "\n")
     spoilerLog.write("Food Trades: " + str(parameters.foodTrades) + "\n")
     spoilerLog.write("Fish Trades: " + str(parameters.fishTrades) + "\n")
-    spoilerLog.write("Doggi Intercept Rewards: " + str(parameters.dogiRewards) + "\n")
+    spoilerLog.write("Dogi Intercept Rewards: " + str(parameters.dogiRewards) + "\n")
     spoilerLog.write("Master Kong: " + str(parameters.mkRewards) + "\n")
     spoilerLog.write("Silvia: " + str(parameters.silvia) + "\n")
     spoilerLog.write("Maphorash: " + str(parameters.maphorash) + "\n")
+    spoilerLog.write("Former Sanctuary Crypt: " + str(parameters.formerSanctuaryCrypt) + "\n")
     spoilerLog.write("Additional Intercept Rewards: " + str(parameters.intRewards) + "\n")
     spoilerLog.write("Skills w/ Boss Bonuses: " + str(parameters.shuffleSkills) + "\n")
     spoilerLog.write("Experience Multiplier: " + str(parameters.expMult) + "\n")
@@ -41,6 +42,8 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
     spoilerLog.write("Theos Start Phase: " + str(parameters.theosPhase) + "\n")
     spoilerLog.write("Origin Start Phase: " + str(parameters.originPhase) + "\n")
     spoilerLog.write("Origin Care Package: " + str(parameters.carePackage) + "\n")
+    spoilerLog.write("BGM shuffle: " + str(parameters.shuffleBgm) + "\n")
+    spoilerLog.write("Essence Key Sanity: " + str(parameters.essenceKeySanity) + "\n")
     spoilerLog.write("Locations:\n")
 
     for location in shuffledLocations:

--- a/script/mp6569.scp
+++ b/script/mp6569.scp
@@ -561,8 +561,33 @@ function "SubEV_B6Boss_Appeal2"
 
 }
 
-
 function "SubEV_Get_Medal"
+{
+	SetStopFlag(STOPFLAG_SIMPLEEVENT2)
+	CallFunc("system:party_reset")
+
+	ChangeAnimation( "LEADER" , "ANI_GET_ITEM", -1 , 1 )
+	ChangeAnimation( "TBOX01" , "ANI_OPEN", -1 , 1 )
+
+	WaitAnimation2( "TBOX01" , -1, 1, "ANI_OPEN",  0)
+	WaitAnimation2( "LEADER" , -1, 1, "ANI_GET_ITEM",  0)
+
+	// ================================================================================================
+
+	CallFunc("rng:0634")	
+
+	SetChrPos("LP_TBOX01", -100000.0f , 0.0f , 0.0f )
+
+	SetFlag( GF_MP6569_TBOX01, 1 )	// 宝箱空けた
+	SetFlag( GF_HELP_A54, 1 )	// チュートリアル：行動メンバー数の変更
+	DelMapMarker( SMI_SUBEVENT, PAGE_MP65xx, MARKER_SUBEV_CRYPT2, 0, 0)		//現代編地下聖堂（宝箱
+	//SetMapMarker( SMI_OPENED_TBOX ,PAGE_MP65xx, MARKER_SUBEV_CRYPT2, -0.09f, -115.66f, -451.00f, -0.09f, -115.66f,MARKER_SUBEV_CRYPT2,MN_D_MP6561,0)
+
+	ResetStopFlag(STOPFLAG_SIMPLEEVENT2)
+}
+
+
+function "SubEV_Get_Medal_Old"
 {
 	SetStopFlag(STOPFLAG_SIMPLEEVENT2)
 	CallFunc("system:party_reset")

--- a/script/mp7411.scp
+++ b/script/mp7411.scp
@@ -4399,7 +4399,8 @@ function "EV_M05S172_ED"
 	CallFunc("rng:0512")
 
 	//マップマーカー
-	SetMapMarker( SMI_SYMBOL ,PAGE_MP120x, MARKER_EV_M05S180, 39.73f, -1414.10f, 10.81f, 39.73f, -1414.10f,MARKER_EV_M05S180,MN_T_VILLAGE_MP1201,0)		//メイン：大空洞へ向かうことになる
+	// removing main event marker in castaway after beating eleftheria
+	// SetMapMarker( SMI_SYMBOL ,PAGE_MP120x, MARKER_EV_M05S180, 39.73f, -1414.10f, 10.81f, 39.73f, -1414.10f,MARKER_EV_M05S180,MN_T_VILLAGE_MP1201,0)		//メイン：大空洞へ向かうことになる
 
 	CallFunc("mp7411:init")
 

--- a/shared/classr.py
+++ b/shared/classr.py
@@ -404,6 +404,16 @@ class access:
       return True
     return False
   
+  def hasEssenceKeyStone(self, requiredEssenceKeyStone):
+    count = 0
+    for item in self.inventoryObjects:
+      if item.itemID == 703: #Essence key stone
+        count += 1
+    
+    if count >= requiredEssenceKeyStone:
+      return True
+    return False
+  
 class guiInput:
   def __init__(self):
     self.seed = None
@@ -422,6 +432,7 @@ class guiInput:
     self.mkRewards = None
     self.silvia = None
     self.maphorash = None
+    self.formerSanctuaryCrypt = None
     self.intRewards = None
     self.expMult = None
     self.expGrowth = None
@@ -435,6 +446,7 @@ class guiInput:
     self.originPhase = None
     self.carePackage = None
     self.shuffleBgm = None
+    self.essenceKeySanity = None
   
   def getSeed(seed):
     guiInput.seed = seed
@@ -481,6 +493,12 @@ class guiInput:
   
   def getShuffleBgm(shuffleBgm):
     guiInput.shuffleBgm = shuffleBgm
+
+  def getEssenceKeySanity(essenceKeySanity):
+    guiInput.essenceKeySanity = essenceKeySanity
+  
+  def getFormerSanctuaryCrypt(formerSanctuaryCrypt):
+    guiInput.formerSanctuaryCrypt = formerSanctuaryCrypt
     
 class interceptReward:
   def __init__(self,stage,rewards):

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -424,7 +424,7 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0423,mp6104,Towal Highway,Baja Tower Approach,Katthew Join,1,-1,Katthew,1,1,0,0,1,0,--------,0
 0424,mp1116,Nostalgia Cape,Nostalgia Cape,Ed Join,1,-1,Ed,1,1,0,0,1,0,--------,0
 0425,mp4110,Vista Ridge,Vista Ridge Upper,Franz Join,1,-1,Franz,1,1,0,0,1,0,--------,0
-0426,mp1201,Calm Inlet,Ricotta and Shoebill Reunite,Shoebill Join,0,-1,Shoebill,1,1,0,0,1,0,--------,0
+0426,mp1201,Calm Inlet,Ricotta and Shoebill Reunite,Shoebill Join,1,-1,Shoebill,1,1,0,0,1,0,--------,0
 0427,mp6109,Eternal Hill,Eternal Hill,Griselda Join,1,-1,Griselda,1,1,0,0,1,0,--------,0
 0428,mp5104,Vista Ridge,Vista Ridge Lower,Master Kong Join,1,-1,Master Kong,1,1,0,0,1,0,--------,0
 0429,mp0011,Lombardia,Opening Cutscene,Adol Join,1,-1,Adol,1,1,0,1,1,0,--------,0

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -632,3 +632,4 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0631,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0632,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0633,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
+0634,mp6561,Former Sanctuary Crypt - B6,Boss Arena,LP_TBOX01,1,218,Combat Medals,1,0,0,0,0,1,--------,0

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -289,7 +289,7 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0288,mp6513,Former Sanctuary Crypt - B1,North Brazier Room,TBOX02,1,620,Empty bottle,1,0,0,0,0,1,mp6513:EvOpenTBox,0
 0289,mp6514m,Sanctuary Crypt - Chamber of Braziers (Past),Wind Tunnel,TBOX01,0,670,Energy Fragment,50,0,0,0,0,1,--------,0
 0290,mp6514m,Sanctuary Crypt - Chamber of Braziers (Past),Wind Tunnel,TBOX02,0,722,Dragon Bone Necklace,1,0,0,0,0,1,--------,0
-0291,mp6519,Former Sanctuary Crypt - B1,Boss Arena,TBOX01,1,542,Hope Stone,1,0,0,0,0,1,mp6519:EvOpenTBox,0
+0291,mp6519,Former Sanctuary Crypt - B1,Boss Arena,TBOX01,0,542,Hope Stone,1,0,0,0,0,1,mp6519:EvOpenTBox,0
 0292,mp6519m,Sanctuary Crypt - Chamber of Braziers (Past),Boss Arena,TBOX01,0,546,Wheel of Eternity,1,0,0,0,0,1,--------,0
 0293,mp6521,Former Sanctuary Crypt - B2,Entrance,TBOX01,0,511,Eye Drops,3,0,0,0,0,1,--------,0
 0294,mp6521,Former Sanctuary Crypt - B2,Entrance,TBOX02,0,703,Essence Key Stone,1,0,0,0,0,1,--------,0


### PR DESCRIPTION

main changes:
- Added setting to include former sanctuary crypt in the location pool. I am not sure how you measured the combat strength for battle logic but I set it to the same strength required for logically defeating the final boss.
- also added a essence key sanity setting to make all essence key stones randomized across the entire game. 

other changes:
- removed a main event map marker after beating elefhteria
- changed equip logic when obtaining 4th flame stone as it was causing dana to equip edelsphere over celesdia
- added the new settings information to the spoiler log 

fixed some flag events for some locations:
- ricotta and shoebill reunite was changed to an event  as it was set as a chest check so you would not get any item from it
- 1st boss chest in former sanctuary was changed to a chest as it was set as an event causing some weird interactions