### PR TITLE
Added Hints + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ These are settings that help with the pacing of the rando. Like most randos Seir
 
 **Essence Key Sanity**: If Former Sanctuary Crypt setting is on, the Essence Key Stones can be placed anywhere in the game and not just within the dungeon itself.
 
+**Hints**: If Hints setting is on, a set of hints will be displayed on the bulletin board in castaway village. They can also be seen in the quest menu.
+
 ## New Progression Items
 The randomizer features a variety of new progression items that are meant to take story gated events and turn them into item gated events to improve the overall experience of the rando. 
 

--- a/Seiren Shuffle.pyw
+++ b/Seiren Shuffle.pyw
@@ -31,8 +31,7 @@ def buttons(inpt):
         parameters.getEssenceKeySanity(app.getCheckBox("essenceKeySanity"))
         parameters.getFormerSanctuaryCrypt(app.getCheckBox("formerSanctuaryCrypt"))
         parameters.getShuffleBgm(app.getCheckBox("shuffleBGM"))
-        parameters.getEssenceKeySanity(app.getCheckBox("essenceKeySanity"))
-        parameters.getFormerSanctuaryCrypt(app.getCheckBox("formerSanctuaryCrypt"))
+        parameters.getHint(app.getCheckBox("hints"))
         rngPatcherMain(parameters) 
         app.okBox("Task Complete", "Seed Generation Complete!")
         
@@ -68,10 +67,10 @@ def goalChange():
         app.setCheckBoxState("superWeapons","disabled")
 
 def charModeChange():
-    if app.getOptionsBox("Character Mode: ") == "Past Dana":
+    if app.getOptionBox("characterMode") == "Past Dana":
         app.setCheckBox("MKRewards", ticked=False)
         app.setCheckBoxState("MKRewards", "disabled")
-    elif app.getOptionsBox("Character Mode: ") == "Past Dana":
+    elif app.getOptionBox("characterMode") == "Standard":
         app.setCheckBox("MKRewards", ticked=True)
         app.setCheckBoxState("MKRewards", "active")
 
@@ -248,6 +247,8 @@ with gui('Seiren Shuffle (An Ys 8 Rando)', '700x850',font = {'size':12}) as app:
     app.setCheckBox("shuffleBGM", ticked=False)
     app.addNamedCheckBox("Essence Key Sanity", "essenceKeySanity", 0, 2)
     app.setCheckBox("essenceKeySanity", ticked=False)
+    app.addNamedCheckBox("Hints", "hints", 0, 3)
+    app.setCheckBox("hints", ticked=False)
     app.stopLabelFrame()
 
     app.startFrame("commands",9,0)

--- a/executable/Seiren Shuffle.spec
+++ b/executable/Seiren Shuffle.spec
@@ -25,4 +25,4 @@ exe = EXE(pyz,
           strip=False,
           upx=False,
           runtime_tmpdir=None,
-          console=True )
+          console=False )

--- a/executable/Seiren Shuffle.spec
+++ b/executable/Seiren Shuffle.spec
@@ -25,4 +25,4 @@ exe = EXE(pyz,
           strip=False,
           upx=False,
           runtime_tmpdir=None,
-          console=False )
+          console=True )

--- a/inc/flag.h
+++ b/inc/flag.h
@@ -2667,7 +2667,7 @@ enum {
 	GF_TBOX_DUMMY127, //Used to check if in a warden fight
 	GF_TBOX_DUMMY128, //Remove monolith flag from tower top
 	GF_TBOX_DUMMY129, //Past Dana Mode
-	GF_TBOX_DUMMY130,
+	GF_TBOX_DUMMY130, //Used for hints
 	GF_TBOX_DUMMY131,
 	GF_TBOX_DUMMY132,
 	GF_TBOX_DUMMY133,

--- a/randomizer/accessLogic.py
+++ b/randomizer/accessLogic.py
@@ -237,7 +237,7 @@ def canAccess(inventory,location,parameters):
             elif location.mapCheckID == 'TBOX01': return True
             else: return False
         elif location.locName == 'Palace Ruins': return True
-        elif location.locRegion == 'Central Stupa': return True
+        elif location.locName == 'Central Stupa': return True
         else: return False
     elif location.locRegion == 'Temple of the Great Tree' and access.canClimb() and (access.canMove(8) or access.canDoubleJump()) and access.past1() and access.hasFlameStones(3) and ((access.past2() and access.past3()) or access.hasDana())\
           and access.canDefeat('Giasburn'):

--- a/randomizer/hint.py
+++ b/randomizer/hint.py
@@ -1,0 +1,369 @@
+import random
+import os
+import sys
+from collections import defaultdict
+import csv
+
+# Bulletin board character portraits
+PORTRAITS = [
+    "DRCHA_ADOL",               # アドル（手帳には載らない）
+    "DRCHA_LAXIA",              # ラクシャ
+    "DRCHA_SAHAD",              # サハド
+    "DRCHA_HUMMEL",             # ヒュンメル
+    "DRCHA_RICOTTA",            # リコッタ
+    "DRCHA_DANA",               # ダーナ★１（非仲間）
+    # 漂流者
+    "DRCHA_DOGI",               # ドギ
+    "DRCHA_BARBAROSS",          # バルバロス船長★１（生存）
+    "DRCHA_ALISON",             # アリスン
+    "DRCHA_ED",                 # エド
+    "DRCHA_BABY",               # アリスンの子供★ホープ（色違い）
+    "DRCHA_CURRAN",             # カーラン卿★１（生存）
+    "DRCHA_KIERGAARD",          # キルゴール★１（生存）
+    "DRCHA_KATRIN",             # カトリーン
+    "DRCHA_NIA",                # シスター・ニア
+    "DRCHA_DINA",               # ディナ
+    "DRCHA_AARON",              # エアラン
+    "DRCHA_REJA",               # レーヤ
+    "DRCHA_MIRALDA",            # ミラルダ
+    "DRCHA_LICHT",              # リヒト
+    "DRCHA_KUINA",              # クイナ
+    "DRCHA_AUSTEN",             # オースティン
+    "DRCHA_SILVIA",             # シルヴィア
+    "DRCHA_THANATOS",           # タナトス
+    "DRCHA_KASHU",              # カシュー
+    "DRCHA_FRANZ",              # フランツ
+    "DRCHA_GRISELDA",           # グリゼルダ
+    # その他
+    "DRCHA_PARO",               # リトル・パロ
+    "DRCHA_BALAENICEPS_REX",    # ハシビロコウ
+    "DRCHA_SKILLMONKY",         # マスターコング★１（非協力）
+    "DRCHA_OLGA",               # オルガ
+    "DRCHA_SARAI",              # サライ
+    "DRCHA_RASTELL",            # ラステル
+    "DRCHA_IO",                 # イオ
+    "DRCHA_HUDDLA",             # ヒドゥラ
+    "DRCHA_MINOS",              # ミノス
+    "DRCHA_NESTOLE",            # ネストール
+    "DRCHA_URRA",               # ウーラ★１（フードあり）
+    "DRCHA_MAIA",               # 大地神マイア
+    # 派生
+    "DRCHA_KIERGAARD2",         # キルゴール★２（死亡）
+    "DRCHA_BARBAROSS2",         # バルバロス船長★２（死亡）
+    "DRCHA_CURRAN2",            # カーラン卿★２（死亡）
+    "DRCHA_CURRAN3",            # カーラン卿★３（復活）
+    "DRCHA_DANA2",              # ダーナ★２（仲間）
+    "DRCHA_BABY2",              # アリスンの子供★ルーク（色違い）
+    "DRCHA_BABY3",              # アリスンの子供★ウィル（色違い）
+    "DRCHA_AUSTEN2",            # オースティン★２（改心）
+    "DRCHA_SKILLMONKY2",        # マスターコング★２（協力）
+    "DRCHA_URRA2",              # ウーラ★２（フード無し）
+]
+
+SKILLS = {
+    "SKILL_ADOL_SP_C1": "Sonic Slide",
+    "SKILL_ADOL_SP_C2": "Arc Shot",
+    "SKILL_ADOL_SP_C3": "Rising Slash",
+    "SKILL_ADOL_SP_C4": "Sword Impact",
+    "SKILL_ADOL_SP_B1": "Force Edge",
+    "SKILL_ADOL_SP_B2": "Aerial Spin",
+    "SKILL_ADOL_SP_B3": "Sky Drive",
+    "SKILL_ADOL_SP_B4": "Tornado Sword",
+    "SKILL_ADOL_SP_B5": "Aura Blade",
+    "SKILL_ADOL_SP_A1": "Blade Rush",
+    "SKILL_ADOL_SP_A2": "Thrust Storm",
+    "SKILL_ADOL_SP_A3": "Brave Charge",
+    "SKILL_SAHAD_SP_C1": "High Wave",
+    "SKILL_SAHAD_SP_C2": "Grand Anchor",
+    "SKILL_SAHAD_SP_C3": "Wild Appeal",
+    "SKILL_SAHAD_SP_C4": "Gale Blow",
+    "SKILL_SAHAD_SP_B1": "Vortex",
+    "SKILL_SAHAD_SP_B2": "Great Ram",
+    "SKILL_SAHAD_SP_B3": "Power Strike",
+    "SKILL_SAHAD_SP_B4": "Seine Toss",
+    "SKILL_SAHAD_SP_B5": "Upper Break",
+    "SKILL_SAHAD_SP_A1": "Magna Wave",
+    "SKILL_SAHAD_SP_A2": "Raging Deluge",
+    "SKILL_SAHAD_SP_A3": "Spiral Anchor",
+    "SKILL_LAXIA_SP_C1": "Dagger Fling",
+    "SKILL_LAXIA_SP_C2": "Wake Up!",
+    "SKILL_LAXIA_SP_C3": "Rapid Thrust",
+    "SKILL_LAXIA_SP_C4": "Needle Break",
+    "SKILL_LAXIA_SP_B1": "Stun Thrust",
+    "SKILL_LAXIA_SP_B2": "Blitz Charge",
+    "SKILL_LAXIA_SP_B3": "Sylphid's Kiss",
+    "SKILL_LAXIA_SP_B4": "Spark Chaser",
+    "SKILL_LAXIA_SP_B5": "Eagle Lancer",
+    "SKILL_LAXIA_SP_A1": "Piercing Tempest",
+    "SKILL_LAXIA_SP_A2": "Precious Impact",
+    "SKILL_LAXIA_SP_A3": "Lethal Raid",
+    "SKILL_HUMMEL_SP_C1": "Burst Shot",
+    "SKILL_HUMMEL_SP_C2": "Venomous Bullet",
+    "SKILL_HUMMEL_SP_C3": "Somersault",
+    "SKILL_HUMMEL_SP_C4": "Quaker",
+    "SKILL_HUMMEL_SP_B1": "Guilty Raid",
+    "SKILL_HUMMEL_SP_B2": "Triple Bomber",
+    "SKILL_HUMMEL_SP_B3": "Judgment",
+    "SKILL_HUMMEL_SP_B4": "Counter Trick",
+    "SKILL_HUMMEL_SP_B5": "Assault Rain",
+    "SKILL_HUMMEL_SP_A1": "Hasty Valor",
+    "SKILL_HUMMEL_SP_A2": "Prominence Shot",
+    "SKILL_HUMMEL_SP_A3": "Firecracker",
+    "SKILL_RICOTTA_SP_C1": "Wild Spin",
+    "SKILL_RICOTTA_SP_C2": "Handmade Trap",
+    "SKILL_RICOTTA_SP_C3": "Screw Fang",
+    "SKILL_RICOTTA_SP_C4": "Bandit Tackle",
+    "SKILL_RICOTTA_SP_B1": "Flame Swing",
+    "SKILL_RICOTTA_SP_B2": "Mighty Orbit",
+    "SKILL_RICOTTA_SP_B3": "Rumble Thorn",
+    "SKILL_RICOTTA_SP_B4": "Beast Attack",
+    "SKILL_RICOTTA_SP_B5": "Green Whip",
+    "SKILL_RICOTTA_SP_A1": "Triple Bang",
+    "SKILL_RICOTTA_SP_A2": "Spiral Drive",
+    "SKILL_RICOTTA_SP_A3": "Dino Throw",
+    "SKILL_DANA_SP_C1": "Twin Edge",
+    "SKILL_DANA_SP_C2": "Sonic Rise",
+    "SKILL_DANA_SP_C3": "Elemental Shot",
+    "SKILL_DANA_SP_C4": "Dragon Spirit",
+    "SKILL_DANA_SP_B1": "Earth Dragon",
+    "SKILL_DANA_SP_B2": "Twin Moon Blade",
+    "SKILL_DANA_SP_B3": "Boomerang Edge",
+    "SKILL_DANA_SP_B4": "Dragon Wave",
+    "SKILL_DANA_SP_B5": "Mistral Edge",
+    "SKILL_DANA_SP_A1": "Ice Age",
+    "SKILL_DANA_SP_A2": "Spiel Round Dance",
+    "SKILL_DANA_SP_A3": "Water Burst",
+}
+
+class Hint:
+    def __init__(self, itemName, quantity, charPortrait, locRegion, locName = '', mapCheckID = '', isFoolish = False, isRequired = False, displayFullLoc = False):
+        self.itemName = itemName
+        self.quantity = quantity
+        self.isFoolish = isFoolish
+        self.isRequired = isRequired #we will define this in spoiler log generation
+        self.charPortrait = charPortrait
+        self.locRegion = locRegion
+        self.locName = locName
+        self.mapCheckID = mapCheckID
+        self.displayFullLoc = displayFullLoc
+
+#This function will create and return a list of all hints that will be displayed ingame
+def createHints(shuffledLocations, parameters):
+    random.seed(parameters.seed)
+    regionHasProgression = findBarrenRegions(shuffledLocations)
+    barrenLocs = []
+    castawayLocs = []
+    alreadyPickedKathleen = 0 #just a flag so select only 1 flame stone
+    randomLocs = [] #I will be giving full location for random checks
+    usefulAdventuringGearLocs = []
+    nonRegions = ["Starting Skill"]# We will also remove some awkward ones like "Adol Starting Skill" as these aren't really checks
+    nonItems = ["Defeated", "End the Lacrimosa"]# Removing the "Boss defeated" item
+    seenBarrenRegions = set()
+
+    for location in shuffledLocations:
+        if any(nonRegion in location.locRegion for nonRegion in nonRegions) or any(nonItem in location.itemName for nonItem in nonItems):
+            continue  # Skip to the next iteration
+        hint = Hint(
+                    itemName=location.itemName,
+                    quantity=location.quantity,
+                    charPortrait=random.choice(list(PORTRAITS)),
+                    locRegion=location.locRegion,
+                    locName=location.locName,
+                    mapCheckID=location.mapCheckID,
+                )
+        if regionHasProgression[location.locRegion] == True: #has progression
+            if location.itemName in ["Grip Gloves", "Glow Stone", "Archeopteryx Wings", "Gale Feather", "Hermit's Scale", "Purifying bell", "Float Shoes"]:
+                usefulAdventuringGearLocs.append(hint)
+            elif location.crew:
+                if location.itemID == 778 and alreadyPickedKathleen:
+                    hint.locName = location.locName
+                    hint.mapCheckID = location.mapCheckID
+                    hint.displayFullLoc = True
+                    randomLocs.append(hint)
+                else:
+                    if location.itemID == 778:
+                        hint.itemName == "Kathleen"
+                    castawayLocs.append(hint)
+                    alreadyPickedKathleen = 1
+            else:
+                hint.locName = location.locName
+                hint.mapCheckID = location.mapCheckID
+                hint.displayFullLoc = True
+                randomLocs.append(hint)
+        else: #region is barren
+            if hint.locRegion not in seenBarrenRegions:
+                hint.isFoolish = True
+                barrenLocs.append(hint)
+                seenBarrenRegions.add(hint.locRegion)
+
+
+    #Now we shuffle the lists, and pick the ones we want, merge them in the same list and return
+    random.shuffle(castawayLocs)
+    random.shuffle(usefulAdventuringGearLocs)
+    random.shuffle(randomLocs)
+    random.shuffle(barrenLocs)
+
+    #Here it is probably a good idea to set these quantities in the randomizer user interface for customizeable hints
+    numberOfAdventureGearLocs = min(len(usefulAdventuringGearLocs), 1)
+    numberOfRandomLocs = min(len(randomLocs), 3)
+    numberOfCastawayLocs = min(len(castawayLocs), 3)
+    numberOfBarrenLocs = min(len(barrenLocs), 4)
+
+    selected_useful_adventure_gear = usefulAdventuringGearLocs[:numberOfAdventureGearLocs]
+    selected_random_locs = randomLocs[:numberOfRandomLocs]
+    selected_castaways = castawayLocs[:numberOfCastawayLocs]
+    selected_barren_locs = barrenLocs[:numberOfBarrenLocs]
+
+    hints = (
+    selected_useful_adventure_gear
+    + selected_random_locs
+    + selected_castaways
+    + selected_barren_locs
+    )
+
+    '''
+    for i, hint in enumerate(hints, start=1):
+        if "SKILL_" in hint.itemName:
+            hint.itemName = SKILLS[hint.itemName]
+        print(f"Hint {i}:")
+        print(f"  Item Name: {hint.itemName}")
+        print(f"  Quantity: {hint.quantity}")
+        print(f"  Is Foolish: {hint.isFoolish}")
+        print(f"  Is Required: {hint.isRequired}")
+        print(f"  Character Portrait: {hint.charPortrait}")
+        print(f"  Location Region: {hint.locRegion}")
+        print(f"  Location Name: {hint.locName}")
+        print(f"  Map Check ID: {hint.mapCheckID}")
+        print("-" * 30)
+    '''
+    return hints #list of Hint of all hints to be displayed
+
+
+
+def findBarrenRegions(shuffledLocations):
+    # isRegionBarren["region"]: True => has progression
+    # isRegionBarren["region"]: False => is barren
+    isRegionBarren = defaultdict(bool)
+
+    for location in shuffledLocations:
+        # once a location.progression = True, the value in the dict will always be true
+        isRegionBarren[location.locRegion] = isRegionBarren[location.locRegion] or location.progression
+    
+    return isRegionBarren
+    
+
+def format_hint(itemName, quantity, hintNumber, isFoolish, isRequired, charPortrait, locRegion, displayFullLoc, locName = '', mapCheckID = ''):
+    
+    hintNumberText = "Hint " + str(hintNumber)
+
+    isRequiredText = "QUEST_KIND_KEY" if isRequired else "QUEST_KIND_NORMAL"
+
+    if "SKILL_" in itemName:
+        itemName = SKILLS[itemName]
+
+    itemText = ''
+    if quantity == 1:
+          itemText =  itemName
+    else:
+        itemText = itemName + " x" + str(quantity)
+
+    specificLocationText = ''
+    if displayFullLoc:
+        specificLocationText = locName + ' - ' + mapCheckID
+
+    if isFoolish:
+        itemName = ""
+        formattedDescription = f"""
+They say that exploring \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+{locRegion} is a foolish choice \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+"""
+    else:
+        formattedDescription = f"""
+They say that \t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+{locRegion} {specificLocationText} rewards {itemText}\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t
+"""
+        
+    return (
+        f"[QUEST]\tGF_TBOX_DUMMY130\t\t\t{itemName}\t{hintNumberText}\t{hintNumberText}\tGF_NPC_2_02_START_EXPLORE\tGF_NPC_2_02_START_EXPLORE\t"
+        f"GF_NPC_2_11_JOIN_DINA\tGF_NPC_7_01_GOTO_TEM\tSMI_NONE\t\t\t\t\t\t\t\t\t-1\t{charPortrait}\t{isRequiredText}\t"
+        f"{formattedDescription}"
+        f"[QUESTSTATE]\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+        f"DF_QS200_START\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+        f"[QUESTEND]\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n"
+    )
+
+# This function is responsible for writing the hints on the quest.csv file to display them in the bulletin board. If hints are off it will Clear the hints from the file
+def generateHint(hints, parameters):
+    random.seed(parameters.seed)
+    exe_dir = os.path.dirname(sys.executable)
+    csv_path = os.path.join(exe_dir, 'text', 'en', 'quest.csv')
+    flag = "// Start of hints\n"
+
+    try:
+        try:
+            with open(csv_path, "r", encoding="utf-8") as file:
+                lines = file.readlines()
+        except FileNotFoundError:
+            lines = []
+
+        # Locate the flag (created this to preserve the quest.csv file structure)
+        if flag in lines:
+            flag_index = lines.index(flag) + 1
+            content_above_flag = lines[:flag_index]  # Keep everything above and including the flag
+        else:
+            content_above_flag = lines + [flag]  # Add the flag if not found
+            flag_index = len(content_above_flag)
+
+        formattedHints = []
+        for index, hint in enumerate(hints, start=1):
+            formattedHints.append(
+                format_hint(
+                    itemName=hint.itemName,
+                    hintNumber=index,
+                    isRequired=hint.isRequired,
+                    isFoolish=hint.isFoolish,
+                    charPortrait=hint.charPortrait,
+                    quantity=hint.quantity,
+                    locRegion=hint.locRegion,
+                    locName=hint.locName,
+                    mapCheckID=hint.mapCheckID,
+                    displayFullLoc=hint.displayFullLoc
+                )
+            )
+
+        # Combine content above the flag with new hints
+        updated_content = content_above_flag + formattedHints
+
+        # Write the updated content back to the file
+        with open(csv_path, "w", encoding="utf-8") as file:
+            file.writelines(updated_content)
+
+        #print("The CSV file has been updated.")
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+if "__name__" == "__main__":
+  hints = [
+      {
+          "item_name": "Sturdy Lumber",
+          "quantity": 3,
+          "locRegion": "Pirate Ship Eleftheria",
+          "locName": "Submerged Hold",
+          "mapCheckID": "TBOX01",
+          "isFoolish": True,
+          "is_required": False,
+      },
+      {
+          "item_name": "Bone Necklace",
+          "quantity": 1,
+          "locRegion": "Pirate Ship Eleftheria",
+          "locName": "Submerged Hold",
+          "mapCheckID": "TBOX01",
+          "isFoolish": False,
+          "is_required": True,
+      },
+  ]
+
+  csv_file_path = "quest.csv"
+  generateHint(hints)

--- a/randomizer/hint.py
+++ b/randomizer/hint.py
@@ -156,7 +156,7 @@ def createHints(shuffledLocations, parameters):
     alreadyPickedKathleen = 0 #just a flag so select only 1 flame stone
     randomLocs = [] #I will be giving full location for random checks
     usefulAdventuringGearLocs = []
-    nonRegions = ["Starting Skill"]# We will also remove some awkward ones like "Adol Starting Skill" as these aren't really checks
+    nonRegions = ["Starting Skill", "Lombardia"]# We will also remove some awkward ones like "Adol Starting Skill" as these aren't really checks
     nonItems = ["Defeated", "End the Lacrimosa"]# Removing the "Boss defeated" item
     seenBarrenRegions = set()
 

--- a/randomizer/hint.py
+++ b/randomizer/hint.py
@@ -269,7 +269,7 @@ def format_hint(itemName, quantity, hintNumber, isFoolish, isRequired, charPortr
 
     specificLocationText = ''
     if displayFullLoc:
-        specificLocationText = locName + ' - ' + mapCheckID
+        specificLocationText = locName
 
     if isFoolish:
         itemName = ""

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -1,7 +1,7 @@
 import shared.classr as classr
 from randomizer.accessLogic import *
 
-def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests):
+def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests, hints):
     sphere = 0
     newInventory = []
     progressionLocations = []
@@ -49,23 +49,20 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
 
     for location in shuffledLocations:
         location.writeSpoiler(spoilerLog)
-
     for location in shuffledLocations:
         if location.locName == 'Opening Cutscene':
             openingCutscene = location
             progressionInventory.append(location)
         else:
             accessibleLocation.append(location)
-        
     spoilerLog.write('\n \n \n')
     spoilerLog.write("Playthrough:\n")
-    
     #We build an initial list of progression items on the way to the goal
     while len(accessibleLocation) != 0 and not win:
         while True:
             itemFound = 0
             for index,location in enumerate(accessibleLocation):
-                if canAccess(progressionInventory,location,parameters) and not any(location.locRegion.find(region) >= 0 for region in blacklistRegion): #Returns true if you can access the location and it is not blacklisted
+                if canAccess(progressionInventory, location, parameters):
                     newLocation = accessibleLocation.pop(index)
                     accessibleItem = classr.inventory(newLocation)
                     if accessibleItem.progression and newLocation.locID not in duplicateChests:
@@ -131,6 +128,12 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
         while len(foundLocations) != 0:
             location = foundLocations.pop(0)
             location.writeSpoiler(spoilerLog)
+            # label required hints
+            if len(hints) > 0:
+                for hint in hints:
+                    if hint.locRegion == location.locRegion and hint.locName == location.locName and hint.mapCheckID == location.mapCheckID:
+                        hint.isRequired = True
+                        break 
         spoilerLog.write('} \n')
 
         while len(newInventory) != 0:
@@ -139,7 +142,7 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
         
         if sphere >= 100: #Added this safety check in case there are other bugs in spoiler generation
             break 
-
+    spoilerLog.flush()
     spoilerLog.close()
 
 def testSeed(progressionLocations,parameters):

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -49,14 +49,17 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
 
     for location in shuffledLocations:
         location.writeSpoiler(spoilerLog)
+
     for location in shuffledLocations:
         if location.locName == 'Opening Cutscene':
             openingCutscene = location
             progressionInventory.append(location)
         else:
             accessibleLocation.append(location)
+
     spoilerLog.write('\n \n \n')
     spoilerLog.write("Playthrough:\n")
+    
     #We build an initial list of progression items on the way to the goal
     while len(accessibleLocation) != 0 and not win:
         while True:

--- a/randomizer/spoiler.py
+++ b/randomizer/spoiler.py
@@ -45,6 +45,7 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
     spoilerLog.write("Origin Care Package: " + str(parameters.carePackage) + "\n")
     spoilerLog.write("BGM shuffle: " + str(parameters.shuffleBgm) + "\n")
     spoilerLog.write("Essence Key Sanity: " + str(parameters.essenceKeySanity) + "\n")
+    spoilerLog.write("Hints: " + str(parameters.hint) + "\n")
     spoilerLog.write("Locations:\n")
 
     for location in shuffledLocations:
@@ -59,7 +60,7 @@ def generateSpoiler(shuffledLocations,parameters,blacklistRegion,duplicateChests
 
     spoilerLog.write('\n \n \n')
     spoilerLog.write("Playthrough:\n")
-    
+
     #We build an initial list of progression items on the way to the goal
     while len(accessibleLocation) != 0 and not win:
         while True:

--- a/shared/classr.py
+++ b/shared/classr.py
@@ -24,13 +24,16 @@ class location:
     print("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '(' + str(self.itemID) + ')x' + str(self.quantity))
 
   def writeSpoiler(self,file):
-    if self.skill:
-      skillName = getSkillInfo(self.itemName)
-      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + skillName[2] + ':' + skillName[1] + '\n')
-    elif self.quantity == 1:
-      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '\n')
-    else:
-      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + ' x ' + str(self.quantity) + '\n')
+    try:
+      if self.skill:
+        skillName = getSkillInfo(self.itemName)
+        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + skillName[2] + ':' + skillName[1] + '\n')
+      elif self.quantity == 1:
+        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '\n')
+      else:
+        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + ' x ' + str(self.quantity) + '\n')
+    except Exception as e:
+        print(f"Error writing spoiler log for location {self.locRegion} - {self.locName} with item {self.itemName} x {str(self.quantity)}: {e}")
 
 class shuffledLocation(location):
   def __init__(self,location):
@@ -281,7 +284,7 @@ class access:
     for item in self.inventoryObjects:
       if item.itemID == 745: #eagle eye orb
         return True
-      return False
+    return False
   
   def hasBoat(self):
     for item in self.inventoryObjects:
@@ -464,6 +467,7 @@ class guiInput:
     self.carePackage = None
     self.shuffleBgm = None
     self.essenceKeySanity = None
+    self.hint = None
   
   def getSeed(seed):
     guiInput.seed = seed
@@ -517,6 +521,9 @@ class guiInput:
   
   def getFormerSanctuaryCrypt(formerSanctuaryCrypt):
     guiInput.formerSanctuaryCrypt = formerSanctuaryCrypt
+  
+  def getHint(hint):
+    guiInput.hint = hint
     
 class interceptReward:
   def __init__(self,stage,rewards):

--- a/shared/classr.py
+++ b/shared/classr.py
@@ -24,16 +24,13 @@ class location:
     print("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '(' + str(self.itemID) + ')x' + str(self.quantity))
 
   def writeSpoiler(self,file):
-    try:
-      if self.skill:
-        skillName = getSkillInfo(self.itemName)
-        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + skillName[2] + ':' + skillName[1] + '\n')
-      elif self.quantity == 1:
-        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '\n')
-      else:
-        file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + ' x ' + str(self.quantity) + '\n')
-    except Exception as e:
-        print(f"Error writing spoiler log for location {self.locRegion} - {self.locName} with item {self.itemName} x {str(self.quantity)}: {e}")
+    if self.skill:
+      skillName = getSkillInfo(self.itemName)
+      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + skillName[2] + ':' + skillName[1] + '\n')
+    elif self.quantity == 1:
+      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + '\n')
+    else:
+      file.write("\t" + self.locRegion + '-' + self.locName + '(' + self.mapCheckID + '): ' + self.itemName + ' x ' + str(self.quantity) + '\n')
 
 class shuffledLocation(location):
   def __init__(self,location):

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -633,4 +633,4 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0632,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0633,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0634,mp6561,Former Sanctuary Crypt - B6,Boss Arena,LP_TBOX01,1,218,Slash Medal,1,0,0,0,0,1,--------,0
-0635,mp6211,Central Stupa,The Ruins of Eternia,Jade Pendant,1,206,jade pendant,1,1,0,0,0,1,--------,0
+0635,mp6211,The Ruins of Eternia,Central Stupa,Jade Pendant,1,206,jade pendant,1,1,0,0,0,1,--------,0


### PR DESCRIPTION
I added hints inspired on wind waker's randomizer hints. So it will basically add the hints to the bulletin board for you to check at the start of seed. I divided the hints in: Adventure gear, castaway, random checks, barren regions. 
Two things I'd like to add in the future are: Making the hints customizable in the GUI, and having more human-like descriptions for the full location for random checks, as, for example, Octus overlook ice age path - TBOX03 is not really understandable.
Perhaps instead of hinting any random check in the game, it would be better to hint only some more isolated/ annoying checks? well I'll keep these ideas in mind.

Fixes:
 - fixed a problem with the mapIncrease function that checks for eagle eye orb for the accessLogic 
 - fixed some spelling issues from the characterMode in the GUI file
 - fixed the locRegion, locName for the jadePendant check in the central stupa
 - fixed some spoiler log writing problems