### PR TITLE
some other fixes

### DIFF
--- a/script/mp6301.scp
+++ b/script/mp6301.scp
@@ -3775,10 +3775,12 @@ function "Entry_warpout_mp6310"
 	SetChrPos("PLAYER1",0.00f,-62.27f,5.69f)
 	Turn("PLAYER1",0.00f,360.0f)
 
-	SetChrPos("PLAYER3",-1.11f,-62.27f,5.69f)
-	Turn("PLAYER3",0.00f,360.0f)
-	SetChrPos("PLAYER2",1.11f,-62.27f,5.69f)
-	Turn("PLAYER2",0.00f,360.0f)
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		SetChrPos("PLAYER3",-1.11f,-62.27f,5.69f)
+		Turn("PLAYER3",0.00f,360.0f)
+		SetChrPos("PLAYER2",1.11f,-62.27f,5.69f)
+		Turn("PLAYER2",0.00f,360.0f)
+	}
 
 	SetChrInfoFlag("PLAYER1", INFOFLAG_NOCHRATARI)
 	SetChrInfoFlag("PLAYER2", INFOFLAG_NOCHRATARI)
@@ -3830,8 +3832,10 @@ function "Entry_warpout_mp6310"
 	Wait(FADE_FAST)
 
 	Wait(20)
-	ExecuteCmd( 2, MoveTo, "PLAYER3" ,-1.11f,-65.50f,5.67f , 0.1f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER2" , 1.11f,-65.50f,5.67f , 0.1f , 0.22f )
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER3" ,-1.11f,-65.50f,5.67f , 0.1f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER2" , 1.11f,-65.50f,5.67f , 0.1f , 0.22f )
+	}
 	Wait(5)
 
 	WaitThread(1)

--- a/script/mp6305.scp
+++ b/script/mp6305.scp
@@ -274,8 +274,10 @@ function "Entry_warpout_mp6302"
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,-212.99f,-0.06f,1.31f , 0.1f , 0.22f )
 
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-212.99f,-0.06f,1.31f , 2.5f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-212.99f,-0.06f,1.31f , 2.5f , 0.22f )
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-212.99f,-0.06f,1.31f , 2.5f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-212.99f,-0.06f,1.31f , 2.5f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )

--- a/script/mp6306.scp
+++ b/script/mp6306.scp
@@ -247,8 +247,10 @@ function "Entry_warpout_mp6303"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,-5.15f,0.39f,0.00f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-5.15f,0.39f,0.00f , 2.5f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-5.15f,0.39f,0.00f , 2.5f , 0.22f )
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-5.15f,0.39f,0.00f , 2.5f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-5.15f,0.39f,0.00f , 2.5f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )
@@ -2008,4 +2010,3 @@ function "EV_M06S163_ED"
 //
 	//èIóπèàóùÇ±Ç±Ç‹Ç≈----------------------------------------------------
 }
-

--- a/script/mp6307.scp
+++ b/script/mp6307.scp
@@ -250,8 +250,10 @@ function "Entry_warpout_mp6304"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,-99.02f,-0.05f,0.00f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-99.02f,-0.05f,0.00f , 2.5f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-99.02f,-0.05f,0.00f , 2.5f , 0.22f )
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-99.02f,-0.05f,0.00f , 2.5f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-99.02f,-0.05f,0.00f , 2.5f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )

--- a/script/mp6308.scp
+++ b/script/mp6308.scp
@@ -246,8 +246,10 @@ function "Entry_warpout_mp6301"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,-297.96f,-0.02f,-8.50f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-297.96f,-0.02f,-8.50f , 2.5f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-297.96f,-0.02f,-8.50f , 2.5f , 0.22f )
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-297.96f,-0.02f,-8.50f , 2.5f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-297.96f,-0.02f,-8.50f , 2.5f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )

--- a/script/mp6310.scp
+++ b/script/mp6310.scp
@@ -94,10 +94,12 @@ function "Entry_warpout_mp6301"
 
 	SetChrPos("PLAYER1",0.00f,-300.00f,25.00f)
 	Turn("PLAYER1",-180.00f,360.0f)
-	SetChrPos("PLAYER2",1.70f,-300.50f,25.00f)
-	Turn("PLAYER2",-180.00f,360.0f)
-	SetChrPos("PLAYER3",-1.70f,-300.50f,25.00f)
-	Turn("PLAYER3",-180.00f,360.0f)
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		SetChrPos("PLAYER2",1.70f,-300.50f,25.00f)
+		Turn("PLAYER2",-180.00f,360.0f)
+		SetChrPos("PLAYER3",-1.70f,-300.50f,25.00f)
+		Turn("PLAYER3",-180.00f,360.0f)
+	}
 
 	SetChrInfoFlag("PLAYER1", INFOFLAG_NOCHRATARI)
 	SetChrInfoFlag("PLAYER2", INFOFLAG_NOCHRATARI)
@@ -148,8 +150,10 @@ function "Entry_warpout_mp6301"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,0.00f ,-297.00f,25.00f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,1.70f  ,-297.66f,25.00f , 0.1f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-1.70f ,-297.66f,25.00f , 0.1f , 0.22f )
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,1.70f  ,-297.66f,25.00f , 0.1f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-1.70f ,-297.66f,25.00f , 0.1f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )
@@ -184,10 +188,12 @@ function "LP_warpin_mp6301"
 
 	SetChrPos("PLAYER1",0.00f,-297.50f,25.00f)
 	Turn("PLAYER1",0.00f,360.0f)
-	SetChrPos("PLAYER2",-1.70f,-296.00f,25.00f)
-	Turn("PLAYER2",0.00f,360.0f)
-	SetChrPos("PLAYER3",1.70f,-296.00f,25.00f)
-	Turn("PLAYER3",0.00f,360.0f)
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		SetChrPos("PLAYER2",-1.70f,-296.00f,25.00f)
+		Turn("PLAYER2",0.00f,360.0f)
+		SetChrPos("PLAYER3",1.70f,-296.00f,25.00f)
+		Turn("PLAYER3",0.00f,360.0f)
+	}
 
 	SetChrInfoFlag("PLAYER1", INFOFLAG_NOCHRATARI)
 	SetChrInfoFlag("PLAYER2", INFOFLAG_NOCHRATARI)
@@ -228,8 +234,10 @@ function "LP_warpin_mp6301"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,0.00f ,-300.00f,25.00f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-1.70f  ,-299.0f,25.00f , 0.1f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,1.70f ,-299.0f,25.00f , 0.1f , 0.22f )
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-1.70f  ,-299.0f,25.00f , 0.1f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,1.70f ,-299.0f,25.00f , 0.1f , 0.22f )
+	}
 
 	FadeIn(FADE_BLACK, FADE_FAST)
 

--- a/script/mp6409.scp
+++ b/script/mp6409.scp
@@ -191,8 +191,11 @@ function "LP_warpin_mp6301"
 	//ƒLƒƒƒ‰ˆÚ“®
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,(this.CHRWORK[CWK_POSX]) , (this.CHRWORK[CWK_POSY] ) ,(this.CHRWORK[CWK_POSZ] ) , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,(this.CHRWORK[CWK_POSX]) , (this.CHRWORK[CWK_POSY] ) ,(this.CHRWORK[CWK_POSZ] ) , 2.60f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,(this.CHRWORK[CWK_POSX]) , (this.CHRWORK[CWK_POSY] ) ,(this.CHRWORK[CWK_POSZ] ) , 2.60f , 0.22f )
+	
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,(this.CHRWORK[CWK_POSX]) , (this.CHRWORK[CWK_POSY] ) ,(this.CHRWORK[CWK_POSZ] ) , 2.60f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,(this.CHRWORK[CWK_POSX]) , (this.CHRWORK[CWK_POSY] ) ,(this.CHRWORK[CWK_POSZ] ) , 2.60f , 0.22f )
+	}
 
 	FadeIn(FADE_BLACK, FADE_FAST)
 
@@ -292,8 +295,10 @@ function "Entry_warpout_mp6301"
 
 	ExecuteCmd( 1, MoveTo, "PLAYER1" ,-182.72f,380.89f,127.53f , 0.1f , 0.22f )
 	Wait(8)
-	ExecuteCmd( 2, MoveTo, "PLAYER2" ,-182.72f,380.89f,127.53f , 2.5f , 0.22f )
-	ExecuteCmd( 3, MoveTo, "PLAYER3" ,-182.72f,380.89f,127.53f , 2.5f , 0.22f )
+	if(!FLAG[GF_TBOX_DUMMY129]) {
+		ExecuteCmd( 2, MoveTo, "PLAYER2" ,-182.72f,380.89f,127.53f , 2.5f , 0.22f )
+		ExecuteCmd( 3, MoveTo, "PLAYER3" ,-182.72f,380.89f,127.53f , 2.5f , 0.22f )
+	}
 	Wait(5)
 
 	ResetChrInfoFlag( "PLAYER1" , INFOFLAG_INVISIBLE )

--- a/script/mp6569.scp
+++ b/script/mp6569.scp
@@ -199,11 +199,13 @@ function "SubEV_B6Boss_Appeal"		//ìoèÍââèo
 	ChangeSubAnimation("LEADER", SUBMOT_MOUTH, ANI_M_WAIT, 1)
 	ChangeSubAnimation("LEADER", SUBMOT_EXT1, ANI_E_LOOKC, 1)
 
-	SetChrPos("PLAYER2",-1.41f,-55.69f,-452.00f)
-	Turn("PLAYER2",1.15f,360.0f)
+	if(! FLAG[GF_TBOX_DUMMY129]) {
+		SetChrPos("PLAYER2",-1.41f,-55.69f,-452.00f)
+		Turn("PLAYER2",1.15f,360.0f)
 
-	SetChrPos("PLAYER3",1.75f,-54.28f,-452.00f)
-	Turn("PLAYER3",1.16f,360.0f)
+		SetChrPos("PLAYER3",1.75f,-54.28f,-452.00f)
+		Turn("PLAYER3",1.16f,360.0f)
+	}
 
 	SetChrPos("ev_b170", 0.0f, -78.0f, -452.0f)
 	Turn("ev_b170", 180.0f, 360.0f)

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -633,5 +633,5 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0631,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0632,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
 0633,none,none,none,none,0,778,Flame Stone,1,1,0,0,1,0,--------,0
-0634,mp6569,Former Sanctuary Crypt - B6,Boss Arena,LP_TBOX01,1,218,Slash Medal,1,0,0,0,0,1,--------,0
+0634,mp6569,Former Sanctuary Crypt - B6,Boss Arena,Meladuma Medals,1,218,Slash Medal,1,0,0,0,0,1,--------,0
 0635,mp6211,The Ruins of Eternia,Central Stupa,Jade Pendant,1,206,jade pendant,1,1,0,0,0,1,--------,0

--- a/shared/database/mapTable.csv
+++ b/shared/database/mapTable.csv
@@ -291,27 +291,27 @@ MN_D_MP6554M,Western Hall,Sanctuary Crypt - Chamber of Magma (Past)
 MN_D_MP6559M,Boss Arena,Sanctuary Crypt - Chamber of Magma (Past)
 MN_D_MP6561M,Big Staircase,Sanctuary Crypt - Chamber of the Final Trial (Past)
 MN_D_MP6569M,Boss Arena,Sanctuary Crypt - Chamber of the Final Trial (Past)
-MN_D_MP6511,Entrance,Former Scantuary Crypt - B1
-MN_D_MP6512,First Brazier,Former Scantuary Crypt - B1
-MN_D_MP6513,North Brazier Room,Former Scantuary Crypt - B1
-MN_D_MP6519,Boss Arena,Former Scantuary Crypt - B1
-MN_D_MP6521,Entrance,Former Scantuary Crypt - B2
-MN_D_MP6522,Stone and Rock Block Puzzle,Former Scantuary Crypt - B2
-MN_D_MP6529,Boss Arena,Former Scantuary Crypt - B2
-MN_D_MP6531,Entrance,Former Scantuary Crypt - B3
-MN_D_MP6532,Floating Block Puzzle,Former Scantuary Crypt - B3
-MN_D_MP6539,Boss Arena,Former Scantuary Crypt - B3
-MN_D_MP6541,Entrance,Former Scantuary Crypt - B4
-MN_D_MP6542,Frozen Statue Room,Former Scantuary Crypt - B4
-MN_D_MP6549,Boss Arena,Former Scantuary Crypt - B4
-MN_D_MP6551,Entrance,Former Scantuary Crypt - B5
-MN_D_MP6552,Eastern Hall,Former Scantuary Crypt - B5
-MN_D_MP6553,Central Chamber North of Entrance,Former Scantuary Crypt - B5
-MN_D_MP6554,Western Hall,Former Scantuary Crypt - B5
-MN_D_MP6555,Large Stairwell,Former Scantuary Crypt - B5
-MN_D_MP6559,Boss Arena,Former Scantuary Crypt - B5
-MN_D_MP6561,Big Staircase,Former Scantuary Crypt - Final Floor
-MN_D_MP6569,Boss Arena,Former Scantuary Crypt - Final Floor
+MN_D_MP6511,Entrance,Former Sanctuary Crypt - B1
+MN_D_MP6512,First Brazier,Former Sanctuary Crypt - B1
+MN_D_MP6513,North Brazier Room,Former Sanctuary Crypt - B1
+MN_D_MP6519,Boss Arena,Former Sanctuary Crypt - B1
+MN_D_MP6521,Entrance,Former Sanctuary Crypt - B2
+MN_D_MP6522,Stone and Rock Block Puzzle,Former Sanctuary Crypt - B2
+MN_D_MP6529,Boss Arena,Former Sanctuary Crypt - B2
+MN_D_MP6531,Entrance,Former Sanctuary Crypt - B3
+MN_D_MP6532,Floating Block Puzzle,Former Sanctuary Crypt - B3
+MN_D_MP6539,Boss Arena,Former Sanctuary Crypt - B3
+MN_D_MP6541,Entrance,Former Sanctuary Crypt - B4
+MN_D_MP6542,Frozen Statue Room,Former Sanctuary Crypt - B4
+MN_D_MP6549,Boss Arena,Former Sanctuary Crypt - B4
+MN_D_MP6551,Entrance,Former Sanctuary Crypt - B5
+MN_D_MP6552,Eastern Hall,Former Sanctuary Crypt - B5
+MN_D_MP6553,Central Chamber North of Entrance,Former Sanctuary Crypt - B5
+MN_D_MP6554,Western Hall,Former Sanctuary Crypt - B5
+MN_D_MP6555,Large Stairwell,Former Sanctuary Crypt - B5
+MN_D_MP6559,Boss Arena,Former Sanctuary Crypt - B5
+MN_D_MP6561,Big Staircase,Former Sanctuary Crypt - Final Floor
+MN_D_MP6569,Boss Arena,Former Sanctuary Crypt - Final Floor
 MN_D_MP1301T2,Entrance,Towering Coral Forest (Night)
 MN_D_MP1302T2,Walkways,Towering Coral Forest (Night)
 MN_D_MP1303T2,After Mid-Boss,Towering Coral Forest (Night)


### PR DESCRIPTION
There are 2 fixes here:

1- (past dana mode): When teleporting around octus overlook, some hardcoded lines that move "player2" and "player3" were causing softlocks. I made it so these lines are only run when not playing past dana.

2- the Patch Files code was modifying the binary files for the former sanc's final floor boss room causing the boss to not appear.
I changed the location's check ID to something that does not include the word 'TBOX' to avoid it. You may need to reinstall the binary file for this map in case you clicked Patch FIles during this glitch.

