### PR TITLE
Some fixes I found today

### DIFF
--- a/Seiren Shuffle.pyw
+++ b/Seiren Shuffle.pyw
@@ -140,9 +140,15 @@ class SelectionSphereFrame(ctk.CTkFrame):
         """ Update sliders and their ranges based on selected goal """
         if choice == "Release the Psyches":
             # Enable both sliders and set range from 1 to 4
-            self.set_slider_range(self.goal_count_scale, 1, 4)
-            self.set_slider_range(self.octus_num_scale, 1, 4)
-            self.numbersOfSteps = 3  # Number of steps = range - 1
+            if self.master.modeFrame.character_mode.get() == "Past Dana":
+                self.set_slider_range(self.goal_count_scale, 1, 5)
+                self.set_slider_range(self.octus_num_scale, 1, 4)
+                self.numbersOfSteps = 4  # Number of steps = range - 1
+            if self.master.modeFrame.character_mode.get() == "Standard":
+                self.set_slider_range(self.goal_count_scale, 1, 4)
+                self.set_slider_range(self.octus_num_scale, 1, 4)
+                self.numbersOfSteps = 3  # Number of steps = range - 1
+            
             self.show_sliders(True)
 
             # Set sliders to pre-determined values
@@ -885,6 +891,9 @@ class App(ctk.CTk):
                     except Exception as e:
                         print(f"Error setting {csv_key}: {str(e)}")
 
+            # Update character mode dependencies
+            self.handle_char_mode_change(settings.get("Game Mode", "Standard"))
+            
             # Special handling for Selection Sphere Frame
             goal = settings.get("Goal", "Release the Psyches")
             goal_count = int(settings.get("goalCount", 4))
@@ -914,9 +923,6 @@ class App(ctk.CTk):
             # Force UI updates
             self.selectionsphereFrame.update_idletasks()
             self.pacingModifiersFrame.update_examples()
-
-            # Update character mode dependencies
-            self.handle_char_mode_change(settings.get("Game Mode", "Standard"))
 
             # Update final boss dependencies
             self.finalBossSettingsFrame.finalBossChange(settings.get("Final Boss", "Theos de Endogram"))

--- a/randomizer/rngPatcher.py
+++ b/randomizer/rngPatcher.py
@@ -1248,7 +1248,7 @@ def buildPsyches(location, parameters):
         WaitCloseWindow()
         ResetStopFlag(STOPFLAG_TALK)
         """
-        psycheFunction = """
+    psycheFunction = """
     function "{0}"
     {{
         if(!FLAG[SF_BOSS_BATTLE] && !FLAG[GF_TBOX_DUMMY127])

--- a/randomizer/rngPatcher.py
+++ b/randomizer/rngPatcher.py
@@ -1239,7 +1239,7 @@ def buildPsyches(location, parameters):
     elif location.itemName == 'Empty Psyches\Magma Fight(DANA)':
         if parameters.charMode == 'Past Dana':
             callPrompt = 'CallFunc("rng:magmaFight")'
-            promptFight = frostFight()
+            promptFight = magmaFight()
         else:
             callPrompt = """
         SetStopFlag(STOPFLAG_TALK)
@@ -1545,7 +1545,7 @@ def magmaFight():
         if(!FLAG[GF_SUBEV_PAST_BOSS_B5])
         {
             SetStopFlag(STOPFLAG_SIMPLEEVENT2)
-            Message("The guardian of the Chamber of Frost is near.")
+            Message("The guardian of the Chamber of Magma is near.")
             WaitPrompt()
             WaitCloseWindow()
             SetFlag( TF_MENU_SELECT, 0 )

--- a/shared/database/location.csv
+++ b/shared/database/location.csv
@@ -616,12 +616,11 @@ locID,mapID,locRegion,locName,mapCheckID,event,itemID,itemName,quantity,progress
 0615,mp6112,Pangaia Plains,Ancient Tree,Master Kong Hummel,1,-1,Master Kong Hummel Defeated,1,1,0,0,0,0,--------,0
 0616,mp5104,Vista Ridge,Vista Ridge Lower,Master Kong Adol,1,-1,Master Kong Adol Defeated,1,1,0,0,0,0,--------,0
 0617,mp6413,Silent Tower,Second Basement,Psyches,1,-1,Empty Psyches,1,0,0,0,0,0,--------,0
-0618,mp6308,Octus Overlook,Path of the Sky Era,Psyches,1,-1,Psyches of the Sky Era,1,1,0,0,0,0,--------,0
 0618,mp6308,Octus Overlook,Path of the Sky Era,Psyches,1,-1,Psyches of the Sky Era\Braziers Fight(DANA),1,1,0,0,0,0,--------,0
 0619,mp6307,Octus Overlook,Path of the Insectoid Era,Psyches,1,-1,Psyches of the Insectoid Era\Stone Fight(DANA),1,1,0,0,0,0,--------,0
 0620,mp6306,Octus Overlook,Path of the Frozen Era,Psyches,1,-1,Psyches of the Frozen Era\Clairvoyance Fight(DANA),1,1,0,0,0,0,--------,0
 0621,mp6305,Octus Overlook,Path of the Ocean Era,Psyches,1,-1,Psyches of the Ocean Era\Frost Fight(DANA),1,1,0,0,0,0,--------,0
-0622,mp6349,Valley of Kings,Boss Arena,Psyches,1,-1,Empty Psyches\Magma Fight(DANA),1,0,0,0,0,0,--------,0
+0622,mp6349,Valley of Kings,Boss Arena,Psyches,1,-1,Empty Psyches\Magma Fight(DANA),1,1,0,0,0,0,--------,0
 0623,mp6370,Archeozoic Chasm,Boss Arena,Psyches,1,-1,Empty Psyches,1,0,0,0,0,0,--------,0
 0624,mp0405,Pirate Ship Eleftheria,Deck,Psyches,1,-1,Empty Psyches,1,0,0,0,0,0,--------,0
 0625,mp6329,Baja Tower,Boss Arena,Psyches,1,-1,Empty Psyches,1,0,0,0,0,0,--------,0


### PR DESCRIPTION
GUI fix:
 - When changing goal mode, now the gui checks whether the character mode is standard or past dana to set the slider to 4 or 5 bosses
 - When importing seed, the slider for Release the Psyches gets imported properly now

Release the Psyches fix:
  - Now the magma fight calls the magmaFight() function instead of frostFight() which was causing magma boss call to not be called ingame
  - Removed a duplicate psyche check  and made the magma psyche check as "progression". These were causing crashes upon generating the spoiler log.